### PR TITLE
Make completions an opt-in feature

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,6 +82,12 @@
           },
           "type": "array"
         },
+        "ty.experimental.completions.enable": {
+          "default": false,
+          "markdownDescription": "Whether to enable completions.",
+          "scope": "window",
+          "type": "boolean"
+        },
         "ty.importStrategy": {
           "default": "fromEnvironment",
           "markdownDescription": "Strategy for loading the `ty` executable. `fromEnvironment` picks up ty from the environment, falling back to the bundled version if needed. `useBundled` uses the version bundled with the extension.",

--- a/src/common/settings.ts
+++ b/src/common/settings.ts
@@ -12,6 +12,12 @@ type ImportStrategy = "fromEnvironment" | "useBundled";
 
 type LogLevel = "error" | "warn" | "info" | "debug" | "trace";
 
+type Experimental = {
+  completions?: {
+    enable?: boolean;
+  };
+};
+
 export interface ISettings {
   cwd: string;
   workspace: string;
@@ -20,6 +26,7 @@ export interface ISettings {
   importStrategy: ImportStrategy;
   logLevel?: LogLevel;
   logFile?: string;
+  experimental?: Experimental;
 }
 
 export function getExtensionSettings(namespace: string): Promise<ISettings[]> {
@@ -98,6 +105,7 @@ export async function getWorkspaceSettings(
     importStrategy: config.get<ImportStrategy>("importStrategy") ?? "fromEnvironment",
     logLevel: config.get<LogLevel>("logLevel"),
     logFile: config.get<string>("logFile"),
+    experimental: config.get<Experimental>("experimental"),
   };
 }
 
@@ -121,6 +129,7 @@ export async function getGlobalSettings(namespace: string): Promise<ISettings> {
     importStrategy: getGlobalValue<ImportStrategy>(config, "importStrategy", "fromEnvironment"),
     logLevel: getOptionalGlobalValue<LogLevel>(config, "logLevel"),
     logFile: getOptionalGlobalValue<string>(config, "logFile"),
+    experimental: getOptionalGlobalValue<Experimental>(config, "experimental"),
   };
 }
 
@@ -134,6 +143,7 @@ export function checkIfConfigurationChanged(
     `${namespace}.path`,
     `${namespace}.logLevel`,
     `${namespace}.logFile`,
+    `${namespace}.experimental.completions.enable`,
   ];
   return settings.some((s) => e.affectsConfiguration(s));
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -104,6 +104,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     onDidGrantWorkspaceTrust(async () => {
       await runServer();
     }),
+    registerCommand(`${serverId}.restart`, async () => {
+      await runServer();
+    }),
     registerCommand(`${serverId}.showLogs`, () => {
       logger.channel.show();
     }),


### PR DESCRIPTION
## Summary

We now expect an `initializationOptions` setting to enable completions.

Closes #7.

## Test Plan

- Hardcoded `TEST` as the returned completions in the LSP.
- Ran `cargo build -p ty` in the Ruff repo.
- Set the hardcoded path in the VS Code extension:
```json
{
    "ty.path": [
        "/Users/crmarsh/workspace/ruff/target/debug/ty"
    ]
}
```
- Started the extension.
- Verified that no completions appeared.
- Enabled the setting:
```json
{
    "ty.path": [
        "/Users/crmarsh/workspace/ruff/target/debug/ty"
    ],
    "ty.experimental.completions.enable": true
}
```
- Verified that the `TEST` completion appeared.
