### PR TITLE
Add contributing docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,30 @@
+# Contributing
+
+## Development
+
+### Getting Started
+
+- Install [`uv`](https://github.com/astral-sh/uv).
+- Install [`just`](https://github.com/casey/just), or see the `justfile` for corresponding commands.
+- Install development dependencies (`just install`).
+- To automatically format the codebase, run: `just fmt`.
+- To run lint and type checks, run: `just check`.
+
+To run the extension, navigate to `src/extension.ts` and run (`F5`). You should see the extension output
+and the language server log messages in the debug console under "ty" and "ty Language Server" respectively.
+
+### Using a custom version of ty
+
+- Clone [ty](https://github.com/astral-sh/ty) to, e.g., `/home/ferris/ty`.
+- Run `cargo build` in the ty repository.
+- Set `ty.path` to `/home/ferris/ty/target/debug/ty` in the VS Code settings.
+
+## Release
+
+- Run `just release` (or manually `uv run --python=3.7 scripts/release.py`).
+  (Run `just release --help` for information on what this script does,
+  and its various options.)
+- Check the changes the script made, copy-edit the changelog, and commit the changes.
+- Create a new PR and merge it.
+- [Create a new Release](https://github.com/astral-sh/ty-vscode/releases/new), enter `x.x.x` (where `x.x.x` is the new version) into the _Choose a tag_ selector. Click _Generate release notes_, curate the release notes and publish the release.
+- The Release workflow publishes the extension to the VS Code marketplace.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ and the language server log messages in the debug console under "ty" and "ty Lan
 
 ## Release
 
-- Run `just release` (or manually `uv run --python=3.7 scripts/release.py`).
+- Run `just release` (or manually `uv run --python=3.8 scripts/release.py`).
   (Run `just release --help` for information on what this script does,
   and its various options.)
 - Check the changes the script made, copy-edit the changelog, and commit the changes.

--- a/justfile
+++ b/justfile
@@ -1,15 +1,21 @@
-default: fmt check
+# List the available recipes
+default:
+  @just --list
 
+# Lock the Python and Node.js dependencies
 lock:
   uv pip compile --python-version 3.8 --generate-hashes -o ./requirements.txt ./pyproject.toml
   npm install --package-lock-only
 
+# Install the dependencies for the bundled tool
 setup:
   uv pip sync --require-hashes ./requirements.txt --target ./bundled/libs
 
-install:
+# Install everything needed for local development
+install: setup
   npm ci
 
+# Check for code quality and type errors
 check:
   uvx ruff check ./bundled/tool ./build ./scripts
   uvx ruff format --check ./bundled/tool ./build ./scripts
@@ -19,20 +25,24 @@ check:
   npm run lint
   npm run tsc
 
+# Format the code
 fmt:
   uvx ruff check --fix ./bundled/tool ./build ./scripts
   uvx ruff format ./bundled/tool ./build ./scripts
   npm run fmt
 
+# Build the VS Code package
 build-package: setup
   npm ci
   npm run vsce-package
 
+# Clean out the build artifacts
 clean:
   rm -rf out
   rm -rf node_modules
   rm -rf .vscode-test
   rm -rf bundled/libs
 
-release:
-  uv run --python=3.7 scripts/release.py
+# Run the release script
+release *ARGS:
+  uv run --python=3.8 scripts/release.py {{ARGS}}


### PR DESCRIPTION
## Summary

This is similar to https://github.com/astral-sh/ruff-vscode/blob/main/CONTRIBUTING.md except that it's tailored towards ty extension which doesn't require any Python dependencies.

## Test Plan

Run the various `just` recipes and also used the `scripts/release.py` script to do the latest release.
