### PR TITLE
Avoid starting the language server if interpreter unavailable

### DIFF
--- a/src/common/python.ts
+++ b/src/common/python.ts
@@ -69,11 +69,11 @@ export async function runPythonExtensionCommand(command: string, ...rest: any[])
 
 export function checkVersion(resolved: ResolvedEnvironment): boolean {
   const version = resolved.version;
-  if (version?.major === 3 && version?.minor >= 7) {
+  if (version?.major === 3 && version?.minor >= 8) {
     return true;
   }
   logger.error(`Python version ${version?.major}.${version?.minor} is not supported.`);
   logger.error(`Selected python path: ${resolved.executable.uri?.fsPath}`);
-  logger.error("Supported versions are 3.7 and above.");
+  logger.error("Supported versions are 3.8 and above.");
   return false;
 }


### PR DESCRIPTION
## Summary

This PR fixes a bug which avoid return an error when a Python interpreter was not selected (as reported on Discord). This would happen if `ty.interpreter` is empty and there's no local or global Python interpreter available. This shouldn't be required once #5 is implemented.

## Test Plan

After this PR, the VS Code extension will provide the "error" log and ask users to select a Python interpreter and not start the language server.

<img width="1724" alt="Screenshot 2025-05-17 at 11 26 21" src="https://github.com/user-attachments/assets/9e66a444-ac50-48ca-8223-3da4f75c8d5b" />
