### PR TITLE
Add `python.ty.disableLanguageServices` config

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,14 +73,11 @@
   "contributes": {
     "configuration": {
       "properties": {
-        "ty.path": {
-          "default": [],
-          "markdownDescription": "Path to a custom `ty` executable, e.g., `[\"/path/to/ty\"]`.",
-          "scope": "resource",
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
+        "python.ty.disableLanguageServices": {
+          "default": false,
+          "markdownDescription": "Whether to disable all language services for ty like completions, hover, goto definition, etc.",
+          "scope": "window",
+          "type": "boolean"
         },
         "ty.experimental.completions.enable": {
           "default": false,
@@ -129,6 +126,15 @@
           "markdownDescription": "Path to the log file for the language server.",
           "scope": "application",
           "type": "string"
+        },
+        "ty.path": {
+          "default": [],
+          "markdownDescription": "Path to a custom `ty` executable, e.g., `[\"/path/to/ty\"]`.",
+          "scope": "resource",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
         },
         "ty.trace.server": {
           "type": "string",

--- a/src/common/settings.ts
+++ b/src/common/settings.ts
@@ -18,6 +18,12 @@ type Experimental = {
   };
 };
 
+type PythonSettings = {
+  ty?: {
+    disableLanguageServices?: boolean;
+  };
+};
+
 export interface ISettings {
   cwd: string;
   workspace: string;
@@ -27,6 +33,7 @@ export interface ISettings {
   logLevel?: LogLevel;
   logFile?: string;
   experimental?: Experimental;
+  python?: PythonSettings;
 }
 
 export function getExtensionSettings(namespace: string): Promise<ISettings[]> {
@@ -82,6 +89,20 @@ export function getInterpreterFromSetting(namespace: string, scope?: Configurati
   return config.get<string[]>("interpreter");
 }
 
+function getPythonSettings(workspace?: WorkspaceFolder): PythonSettings | undefined {
+  const config = getConfiguration("python", workspace?.uri);
+  const disableLanguageServices = config.get<boolean>("ty.disableLanguageServices");
+  if (disableLanguageServices !== undefined) {
+    return {
+      ty: {
+        disableLanguageServices,
+      },
+    };
+  } else {
+    return undefined;
+  }
+}
+
 export async function getWorkspaceSettings(
   namespace: string,
   workspace: WorkspaceFolder,
@@ -106,6 +127,7 @@ export async function getWorkspaceSettings(
     logLevel: config.get<LogLevel>("logLevel"),
     logFile: config.get<string>("logFile"),
     experimental: config.get<Experimental>("experimental"),
+    python: getPythonSettings(workspace),
   };
 }
 
@@ -130,6 +152,7 @@ export async function getGlobalSettings(namespace: string): Promise<ISettings> {
     logLevel: getOptionalGlobalValue<LogLevel>(config, "logLevel"),
     logFile: getOptionalGlobalValue<string>(config, "logFile"),
     experimental: getOptionalGlobalValue<Experimental>(config, "experimental"),
+    python: getPythonSettings(),
   };
 }
 
@@ -144,6 +167,7 @@ export function checkIfConfigurationChanged(
     `${namespace}.logLevel`,
     `${namespace}.logFile`,
     `${namespace}.experimental.completions.enable`,
+    "python.ty.disableLanguageServices",
   ];
   return settings.some((s) => e.affectsConfiguration(s));
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -134,6 +134,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       await runServer();
     }),
     onDidChangeConfiguration(async (e: vscode.ConfigurationChangeEvent) => {
+      // TODO(dhruvmanila): Notify the server with `DidChangeConfigurationNotification` and let
+      // the server pull in the updated configuration.
       if (checkIfConfigurationChanged(e, serverId)) {
         await runServer();
       }


### PR DESCRIPTION
## Summary

PR adding support for it in the server: https://github.com/astral-sh/ruff/pull/18230

This PR adds support for `python.ty.disableLanguageServices` in the extension to extract the value and pass it as server setting.

## Test Plan

<!-- How was it tested? -->
