### PR TITLE
set `python.languageServer` to `None` automatically to prevent pylance from interfering with ty's language server

### DIFF
--- a/package.json
+++ b/package.json
@@ -142,6 +142,9 @@
         }
       }
     },
+    "configurationDefaults": {
+      "python.languageServer": "None"
+    },
     "commands": [
       {
         "title": "Restart server",


### PR DESCRIPTION
<!--
Thank you for contributing to ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

i noticed that the readme recommends changing this setting, but we can configure the extension to do this automatically.

