### PR TITLE
Add note about completions

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,18 @@ Currently, the extension supports the following features:
 - Hover type information for symbols
 - Go to type definition
 - Inlay hints for assignment targets
-- [Completions](#completionsenable)
+- Completions
+
+> **Note:**
+>
+> Completions is an experimental feature and requires explicit opt-in to be enabled via the
+> following setting in your `settings.json`:
+>
+> ```json
+> {
+>   "ty.experimental.completions.enable": true
+> }
+> ```
 
 > **Note:**
 >


### PR DESCRIPTION
Replace the (dead) link to completions setting and instead add a note. My main motivation is that the actual docs link is in the ty repository which could get outdated. I'd prefer to have a link to the actual docs once that's published.

[Rendered](https://github.com/astral-sh/ty-vscode/blob/dhruv/completions-note/README.md)