### PR TITLE
Remove the experimental config section

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,17 +28,6 @@ Currently, the extension supports the following features:
 
 > **Note:**
 >
-> Completions is an experimental feature and requires explicit opt-in to be enabled via the
-> following setting in your `settings.json`:
->
-> ```json
-> {
->   "ty.experimental.completions.enable": true
-> }
-> ```
-
-> **Note:**
->
 > If you want to test the language server features like completions, go to type definition, etc., it's
 > recommended to disable the language server from the [Python extension](https://marketplace.visualstudio.com/items?itemName=ms-python.python) (if installed) by adding the
 > following [setting](https://code.visualstudio.com/docs/python/settings-reference#_intellisense-engine-settings) to your `settings.json`:

--- a/package.json
+++ b/package.json
@@ -79,12 +79,6 @@
           "scope": "window",
           "type": "boolean"
         },
-        "ty.experimental.completions.enable": {
-          "default": false,
-          "markdownDescription": "Whether to enable completions.",
-          "scope": "window",
-          "type": "boolean"
-        },
         "ty.importStrategy": {
           "default": "fromEnvironment",
           "markdownDescription": "Strategy for loading the `ty` executable. `fromEnvironment` picks up ty from the environment, falling back to the bundled version if needed. `useBundled` uses the version bundled with the extension.",

--- a/src/common/settings.ts
+++ b/src/common/settings.ts
@@ -12,12 +12,6 @@ type ImportStrategy = "fromEnvironment" | "useBundled";
 
 type LogLevel = "error" | "warn" | "info" | "debug" | "trace";
 
-type Experimental = {
-  completions?: {
-    enable?: boolean;
-  };
-};
-
 type PythonSettings = {
   ty?: {
     disableLanguageServices?: boolean;
@@ -32,7 +26,6 @@ export interface ISettings {
   importStrategy: ImportStrategy;
   logLevel?: LogLevel;
   logFile?: string;
-  experimental?: Experimental;
   python?: PythonSettings;
 }
 
@@ -126,7 +119,6 @@ export async function getWorkspaceSettings(
     importStrategy: config.get<ImportStrategy>("importStrategy") ?? "fromEnvironment",
     logLevel: config.get<LogLevel>("logLevel"),
     logFile: config.get<string>("logFile"),
-    experimental: config.get<Experimental>("experimental"),
     python: getPythonSettings(workspace),
   };
 }
@@ -151,7 +143,6 @@ export async function getGlobalSettings(namespace: string): Promise<ISettings> {
     importStrategy: getGlobalValue<ImportStrategy>(config, "importStrategy", "fromEnvironment"),
     logLevel: getOptionalGlobalValue<LogLevel>(config, "logLevel"),
     logFile: getOptionalGlobalValue<string>(config, "logFile"),
-    experimental: getOptionalGlobalValue<Experimental>(config, "experimental"),
     python: getPythonSettings(),
   };
 }


### PR DESCRIPTION
## Summary

Following up on https://github.com/astral-sh/ruff/pull/18650, this PR removes the `experimental.completions.enable` config from the extension.
