### PR TITLE
Add support for `ty.diagnosticMode`

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,20 @@
           "scope": "window",
           "type": "boolean"
         },
+        "ty.diagnosticMode": {
+          "default": "openFilesOnly",
+          "markdownDescription": "Analysis scope for showing diagnostics.",
+          "enum": [
+            "openFilesOnly",
+            "workspace"
+          ],
+          "enumDescriptions": [
+            "Analyzes and reports errors on only open files.",
+            "Analyzes and reports errors on all files in the workspace."
+          ],
+          "scope": "resource",
+          "type": "string"
+        },
         "ty.importStrategy": {
           "default": "fromEnvironment",
           "markdownDescription": "Strategy for loading the `ty` executable. `fromEnvironment` picks up ty from the environment, falling back to the bundled version if needed. `useBundled` uses the version bundled with the extension.",

--- a/src/common/settings.ts
+++ b/src/common/settings.ts
@@ -18,12 +18,15 @@ type PythonSettings = {
   };
 };
 
+type DiagnosticMode = "openFilesOnly" | "workspace";
+
 export interface ISettings {
   cwd: string;
   workspace: string;
   path: string[];
   interpreter: string[];
   importStrategy: ImportStrategy;
+  diagnosticMode: DiagnosticMode;
   logLevel?: LogLevel;
   logFile?: string;
   python?: PythonSettings;
@@ -117,6 +120,7 @@ export async function getWorkspaceSettings(
     path: resolveVariables(config.get<string[]>("path") ?? [], workspace),
     interpreter,
     importStrategy: config.get<ImportStrategy>("importStrategy") ?? "fromEnvironment",
+    diagnosticMode: config.get<DiagnosticMode>("diagnosticMode") ?? "openFilesOnly",
     logLevel: config.get<LogLevel>("logLevel"),
     logFile: config.get<string>("logFile"),
     python: getPythonSettings(workspace),
@@ -141,6 +145,7 @@ export async function getGlobalSettings(namespace: string): Promise<ISettings> {
     path: getGlobalValue<string[]>(config, "path", []),
     interpreter: [],
     importStrategy: getGlobalValue<ImportStrategy>(config, "importStrategy", "fromEnvironment"),
+    diagnosticMode: getGlobalValue<DiagnosticMode>(config, "diagnosticMode", "openFilesOnly"),
     logLevel: getOptionalGlobalValue<LogLevel>(config, "logLevel"),
     logFile: getOptionalGlobalValue<string>(config, "logFile"),
     python: getPythonSettings(),
@@ -157,7 +162,7 @@ export function checkIfConfigurationChanged(
     `${namespace}.path`,
     `${namespace}.logLevel`,
     `${namespace}.logFile`,
-    `${namespace}.experimental.completions.enable`,
+    `${namespace}.diagnosticMode`,
     "python.ty.disableLanguageServices",
   ];
   return settings.some((s) => e.affectsConfiguration(s));


### PR DESCRIPTION
## Summary

This PR adds support for `ty.diagnosticMode` for https://github.com/astral-sh/ruff/pull/18939.

## Test Plan

Refer to the test plain in the above PR.
