### PR TITLE
Add middleware that enhances the `ty` configuration section with the active Python interpreter

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -3,7 +3,6 @@ import {
   ResponseError,
   CancellationToken,
   DidChangeConfigurationNotification,
-  type DidChangeConfigurationRegistrationOptions,
 } from "vscode-languageclient";
 import { Uri } from "vscode";
 import type { PythonExtension } from "@vscode/python-extension";
@@ -25,17 +24,7 @@ export function createTyMiddleware(pythonExtension: PythonExtension): TyMiddlewa
 
       for (const registration of params.registrations) {
         if (registration.method === DidChangeConfigurationNotification.method) {
-          const registrationOptions =
-            (registration.registerOptions as DidChangeConfigurationRegistrationOptions) ?? null;
-          const section = registrationOptions?.section;
-
-          if (Array.isArray(section) && section.includes("ty")) {
-            didChangeRegistrations.add(registration.id);
-          } else if (section === "ty") {
-            didChangeRegistrations.add(registration.id);
-          } else if (section == null) {
-            didChangeRegistrations.add(registration.id);
-          }
+          didChangeRegistrations.add(registration.id);
         }
       }
     },

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,0 +1,90 @@
+import {
+  type Middleware,
+  ResponseError,
+  CancellationToken,
+  DidChangeConfigurationNotification,
+  type DidChangeConfigurationRegistrationOptions,
+} from "vscode-languageclient";
+import { Uri } from "vscode";
+import type { PythonExtension } from "@vscode/python-extension";
+
+interface TyMiddleware extends Middleware {
+  isDidChangeConfigurationRegistered(): boolean;
+}
+
+export function createTyMiddleware(pythonExtension: PythonExtension): TyMiddleware {
+  const didChangeRegistrations = new Set<string>();
+
+  const middleware: TyMiddleware = {
+    isDidChangeConfigurationRegistered() {
+      return didChangeRegistrations.size > 0;
+    },
+
+    async handleRegisterCapability(params, next) {
+      await next(params, CancellationToken.None);
+
+      for (const registration of params.registrations) {
+        if (registration.method === DidChangeConfigurationNotification.method) {
+          const registrationOptions =
+            (registration.registerOptions as DidChangeConfigurationRegistrationOptions) ?? null;
+          const section = registrationOptions?.section;
+
+          if (Array.isArray(section) && section.includes("ty")) {
+            didChangeRegistrations.add(registration.id);
+          } else if (section === "ty") {
+            didChangeRegistrations.add(registration.id);
+          } else if (section == null) {
+            didChangeRegistrations.add(registration.id);
+          }
+        }
+      }
+    },
+
+    async handleUnregisterCapability(params, next) {
+      await next(params, CancellationToken.None);
+
+      for (const registration of params.unregisterations) {
+        if (registration.method === DidChangeConfigurationNotification.method) {
+          didChangeRegistrations.delete(registration.id);
+        }
+      }
+    },
+
+    workspace: {
+      /**
+       * Enriches the configuration response with the active Python environment
+       * as reported by the Python extension (respecting the scope URI).
+       * The implementation only checks for the "ty" section in the
+       * configuration response but not specifically for `ty.pythonExtension.activeEnvironment`.
+       */
+      async configuration(params, token, next) {
+        const response = await next(params, token);
+
+        if (response instanceof ResponseError) {
+          return response;
+        }
+
+        return params.items.map((param, index) => {
+          const result = response[index];
+
+          if (param.section === "ty") {
+            const scopeUri = param.scopeUri ? Uri.parse(param.scopeUri) : undefined;
+            const activeEnvironment =
+              pythonExtension.environments.getActiveEnvironmentPath(scopeUri);
+
+            return {
+              ...result,
+
+              pythonExtension: {
+                ...result?.pythonExtension,
+                activeEnvironment,
+              },
+            };
+          }
+        });
+      },
+    },
+  };
+
+  return middleware;
+}

--- a/src/common/logger.ts
+++ b/src/common/logger.ts
@@ -1,4 +1,4 @@
-import * as util from "util";
+import * as util from "node:util";
 import * as vscode from "vscode";
 
 class ExtensionLogger {

--- a/src/common/python.ts
+++ b/src/common/python.ts
@@ -1,6 +1,6 @@
-import { commands, Disposable, Event, EventEmitter, Uri } from "vscode";
+import { commands, type Disposable, type Event, EventEmitter, type Uri } from "vscode";
 import { logger } from "./logger";
-import { PythonExtension, ResolvedEnvironment } from "@vscode/python-extension";
+import { PythonExtension, type ResolvedEnvironment } from "@vscode/python-extension";
 
 export interface IInterpreterDetails {
   path?: string[];
@@ -12,28 +12,27 @@ export const onDidChangePythonInterpreter: Event<IInterpreterDetails> =
   onDidChangePythonInterpreterEvent.event;
 
 let _api: PythonExtension | undefined;
-async function getPythonExtensionAPI(): Promise<PythonExtension | undefined> {
-  if (_api) {
-    return _api;
-  }
-  _api = await PythonExtension.api();
-  return _api;
+export async function getPythonExtensionAPI(): Promise<PythonExtension> {
+  const api = _api || (await PythonExtension.api());
+  _api = api;
+  return api;
 }
 
 export async function initializePython(disposables: Disposable[]): Promise<void> {
   try {
     const api = await getPythonExtensionAPI();
 
-    if (api) {
-      disposables.push(
-        api.environments.onDidChangeActiveEnvironmentPath((e) => {
-          onDidChangePythonInterpreterEvent.fire({ path: [e.path], resource: e.resource?.uri });
-        }),
-      );
+    disposables.push(
+      api.environments.onDidChangeActiveEnvironmentPath((e) => {
+        onDidChangePythonInterpreterEvent.fire({
+          path: [e.path],
+          resource: e.resource?.uri,
+        });
+      }),
+    );
 
-      logger.info("Waiting for interpreter from python extension.");
-      onDidChangePythonInterpreterEvent.fire(await getInterpreterDetails());
-    }
+    logger.info("Waiting for interpreter from python extension.");
+    onDidChangePythonInterpreterEvent.fire(await getInterpreterDetails());
   } catch (error) {
     logger.error("Error initializing python: ", error);
   }
@@ -43,13 +42,13 @@ export async function resolveInterpreter(
   interpreter: string[],
 ): Promise<ResolvedEnvironment | undefined> {
   const api = await getPythonExtensionAPI();
-  return api?.environments.resolveEnvironment(interpreter[0]);
+  return api.environments.resolveEnvironment(interpreter[0]);
 }
 
 export async function getInterpreterDetails(resource?: Uri): Promise<IInterpreterDetails> {
   const api = await getPythonExtensionAPI();
-  const environment = await api?.environments.resolveEnvironment(
-    api?.environments.getActiveEnvironmentPath(resource),
+  const environment = await api.environments.resolveEnvironment(
+    api.environments.getActiveEnvironmentPath(resource),
   );
   if (environment?.executable.uri && checkVersion(environment)) {
     return { path: [environment?.executable.uri.fsPath], resource };
@@ -59,7 +58,7 @@ export async function getInterpreterDetails(resource?: Uri): Promise<IInterprete
 
 export async function getDebuggerPath(): Promise<string | undefined> {
   const api = await getPythonExtensionAPI();
-  return api?.debug.getDebuggerPackagePath();
+  return api.debug.getDebuggerPackagePath();
 }
 
 export async function runPythonExtensionCommand(command: string, ...rest: any[]) {

--- a/src/common/server.ts
+++ b/src/common/server.ts
@@ -234,10 +234,12 @@ export async function startServer(
     }),
 
     pythonExtension.environments.onDidChangeActiveEnvironmentPath(() => {
+      // If the Python interpreter changed and the server registered for `didChangeConfiguration`,
+      // notifications, send the notification to the server so that it can request the updated
+      // interpreter settings.
       if (middleware.isDidChangeConfigurationRegistered()) {
         logger.debug("Python interpreter changed, sending DidChangeConfigurationNotification");
 
-        // If the Python interpreter changes,
         newLSClient.sendNotification(DidChangeConfigurationNotification.type, undefined);
       }
     }),

--- a/src/common/settings.ts
+++ b/src/common/settings.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   ConfigurationChangeEvent,
   ConfigurationScope,
   WorkspaceConfiguration,
@@ -94,9 +94,9 @@ function getPythonSettings(workspace?: WorkspaceFolder): PythonSettings | undefi
         disableLanguageServices,
       },
     };
-  } else {
-    return undefined;
   }
+
+  return undefined;
 }
 
 export async function getWorkspaceSettings(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,5 +1,5 @@
 import * as vscode from "vscode";
-import { LanguageClient } from "vscode-languageclient/node";
+import type { LanguageClient } from "vscode-languageclient/node";
 import { LazyOutputChannel, logger } from "./common/logger";
 import {
   checkVersion,
@@ -107,7 +107,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
             workspaceSettings.interpreter.join(" "),
           );
           return;
-        } else if (!checkVersion(resolvedEnvironment)) {
+        }
+
+        if (!checkVersion(resolvedEnvironment)) {
           return;
         }
       }
@@ -159,9 +161,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     if (vscode.workspace.isTrusted) {
       const interpreter = getInterpreterFromSetting(serverId);
       if (interpreter === undefined || interpreter.length === 0) {
-        logger.info(`Python extension loading`);
+        logger.info("Python extension loading");
         await initializePython(context.subscriptions);
-        logger.info(`Python extension loaded`);
+        logger.info("Python extension loaded");
         return; // The `onDidChangePythonInterpreter` event will trigger the server start.
       }
     }


### PR DESCRIPTION
## Summary

One step closer towards https://github.com/astral-sh/ty-vscode/issues/26


This PR adds a custom middleware that intercepts the `configuration` request and it adds the information for the selected and active python interpreter. The value returned by the Python extension doesn't necessarily have to point to a valid python environment. But we can use it as a fallback if it does.

## Test Plan


https://github.com/user-attachments/assets/b53fa5d3-cd78-41c4-a4e7-4e96a3a8c4ef
