### PR TITLE
Scope `diagnosticMode`, `importStrategy`, `path` to window

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
             "Analyzes and reports errors on only open files.",
             "Analyzes and reports errors on all files in the workspace."
           ],
-          "scope": "resource",
+          "scope": "window",
           "type": "string"
         },
         "ty.importStrategy": {
@@ -110,7 +110,7 @@
         "ty.interpreter": {
           "default": [],
           "markdownDescription": "Path to a Python interpreter to use to find the `ty` executable.",
-          "scope": "resource",
+          "scope": "window",
           "items": {
             "type": "string"
           },
@@ -138,7 +138,7 @@
         "ty.path": {
           "default": [],
           "markdownDescription": "Path to a custom `ty` executable, e.g., `[\"/path/to/ty\"]`.",
-          "scope": "resource",
+          "scope": "window",
           "items": {
             "type": "string"
           },


### PR DESCRIPTION
## Summary

This PR updates the scope of the following settings to use `window`:
- `ty.diagnosticMode`
- `ty.importStrategy`
- `ty.path`

The main difference between `window` and `resource` is that in the latter a user is allowed to change these settings for individual folders in a multi-root workspace. But, that doesn't make sense as `ty.path` is the path to the `ty` executable and the extension starts a single server for each window instance. Same goes for other settings as well.

## Test Plan

I tested that these settings cannot be set for individual folders when there are multiple of them in a single workspace:

<img width="1099" height="258" alt="Screenshot 2025-07-28 at 13 58 41" src="https://github.com/user-attachments/assets/86241551-9403-48b9-a6b5-cd5f776eb5d0" />

