### PR TITLE
Simplify settings handling, delegate to `workspace/configuration`

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
   "contributes": {
     "configuration": {
       "properties": {
-        "python.ty.disableLanguageServices": {
+        "ty.disableLanguageServices": {
           "default": false,
           "markdownDescription": "Whether to disable all language services for ty like completions, hover, goto definition, etc.",
           "scope": "window",

--- a/package.json
+++ b/package.json
@@ -73,6 +73,14 @@
   "contributes": {
     "configuration": {
       "properties": {
+        "python.ty.disableLanguageServices": {
+          "default": false,
+          "markdownDescription": "Whether to disable all language services for ty like completions, hover, goto definition, etc.",
+          "markdownDeprecationMessage": "**Deprecated**: Please use `ty.disableLanguageServices` instead.",
+          "deprecationMessage": "Deprecated: Please use ty.disableLanguageServices instead.",
+          "scope": "window",
+          "type": "boolean"
+        },
         "ty.disableLanguageServices": {
           "default": false,
           "markdownDescription": "Whether to disable all language services for ty like completions, hover, goto definition, etc.",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,7 +11,7 @@ import { startServer, stopServer } from "./common/server";
 import {
   checkIfConfigurationChanged,
   getInterpreterFromSetting,
-  getWorkspaceSettings,
+  getExtensionSettings,
 } from "./common/settings";
 import { loadServerDefaults } from "./common/setup";
 import { registerLanguageStatusItem, updateStatus } from "./common/status";
@@ -78,10 +78,10 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       }
 
       const projectRoot = await getProjectRoot();
-      const workspaceSettings = await getWorkspaceSettings(serverId, projectRoot);
+      const settings = await getExtensionSettings(serverId, projectRoot);
 
       if (vscode.workspace.isTrusted) {
-        if (workspaceSettings.interpreter.length === 0) {
+        if (settings.interpreter.length === 0) {
           updateStatus(
             vscode.l10n.t("Please select a Python interpreter."),
             vscode.LanguageStatusSeverity.Error,
@@ -95,8 +95,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
           return;
         }
 
-        logger.info(`Using interpreter: ${workspaceSettings.interpreter.join(" ")}`);
-        const resolvedEnvironment = await resolveInterpreter(workspaceSettings.interpreter);
+        logger.info(`Using interpreter: ${settings.interpreter.join(" ")}`);
+        const resolvedEnvironment = await resolveInterpreter(settings.interpreter);
         if (resolvedEnvironment === undefined) {
           updateStatus(
             vscode.l10n.t("Python interpreter not found."),
@@ -104,7 +104,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
           );
           logger.error(
             "Unable to find any Python environment for the interpreter path:",
-            workspaceSettings.interpreter.join(" "),
+            settings.interpreter.join(" "),
           );
           return;
         }
@@ -115,7 +115,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       }
 
       lsClient = await startServer(
-        workspaceSettings,
+        settings,
         serverId,
         serverName,
         outputChannel,


### PR DESCRIPTION
# Summary

Related PR for ty server: https://github.com/astral-sh/ruff/pull/19614

This PR simplifies the settings handling in the extension by:
- Replace `IInitializationOptions` with `InitializationOptions` that only contains `logLevel` and `logFile`
- Let server ask for workspace specific options via the `workspace/configuration` request
- Rename `ISettings` to `ExtensionSettings` as now that only contains settings specific to VS Code
- Rename `python.ty.disableLanguageServices` to `ty.disableLanguageServices`

## Test Plan

Refer to the test plan in https://github.com/astral-sh/ruff/pull/19614 specific to VS Code.
