### PR TITLE
[ty] Add `ty.experimental.rename` setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,6 +101,12 @@
           "scope": "window",
           "type": "string"
         },
+        "ty.experimental.rename": {
+          "default": false,
+          "markdownDescription": "Enable experimental support for renaming symbols in ty.",
+          "scope": "window",
+          "type": "boolean"
+        },
         "ty.importStrategy": {
           "default": "fromEnvironment",
           "markdownDescription": "Strategy for loading the `ty` executable. `fromEnvironment` picks up ty from the environment, falling back to the bundled version if needed. `useBundled` uses the version bundled with the extension.",

--- a/src/common/settings.ts
+++ b/src/common/settings.ts
@@ -118,6 +118,7 @@ export function checkIfConfigurationChanged(
     // TODO: Remove these once `workspace/didChangeConfiguration` is supported in the server
     `${namespace}.diagnosticMode`,
     `${namespace}.disableLanguageServices`,
+    `${namespace}.experimental.rename`,
   ];
   return settings.some((s) => e.affectsConfiguration(s));
 }


### PR DESCRIPTION
## Summary

This is a complementary PR to https://github.com/astral-sh/ruff/pull/19800 that adds the `ty.experimental.rename` setting in the extension.

## Test Plan

Refer to the test plan in the PR.
