### PR TITLE
Add `ty.inlayHints.callArgumentNames` config option

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,6 +127,12 @@
           "scope": "window",
           "type": "boolean"
         },
+        "ty.inlayHints.callArgumentNames": {
+          "default": true,
+          "markdownDescription": "Whether to enable inlay hints for call argument names.",
+          "scope": "window",
+          "type": "boolean"
+        },
         "ty.interpreter": {
           "default": [],
           "markdownDescription": "Path to a Python interpreter to use to find the `ty` executable.",

--- a/src/common/settings.ts
+++ b/src/common/settings.ts
@@ -119,7 +119,7 @@ export function checkIfConfigurationChanged(
     `${namespace}.diagnosticMode`,
     `${namespace}.disableLanguageServices`,
     `${namespace}.experimental.rename`,
-    `${namespace}.inlayHints.variableTypes`,
+    `${namespace}.inlayHints`,
   ];
   return settings.some((s) => e.affectsConfiguration(s));
 }


### PR DESCRIPTION
## Summary

Related to https://github.com/astral-sh/ruff/pull/19269, this PR defines the `ty.inlayHints.callArgumentNames` setting in the VS Code extension.