### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,6 +1,11 @@
 name: Release
 on:
   workflow_dispatch:
+    inputs:
+      prerelease:
+        description: "Build as prerelease/nightly"
+        type: boolean
+        default: false
   release:
     types: [published]
 
@@ -15,7 +20,8 @@ jobs:
     name: "Build ID"
     runs-on: ubuntu-latest
     outputs:
-      build-id: ${{ steps.build-id-generator.outputs.build-id }}
+      release-build-id: ${{ steps.release-build-id-generator.outputs.release-build-id }}
+      nightly-build-id: ${{ steps.nightly-build-id-generator.outputs.nightly-build-id }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -24,16 +30,20 @@ jobs:
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.x"
-      - name: Generate Build ID
-        id: build-id-generator
+      - name: Generate Build ID (release)
+        if: ${{ (github.event_name == 'workflow_dispatch' && !inputs.prerelease) || !github.event.release.prerelease }}
+        id: release-build-id-generator
         run: |
-          if [[ "${{ github.event.release.prerelease }}" = "true" ]]; then
-            build_id="$(python -m build.generate_build_id --pre-release)"
-          else
-            build_id="$(python -m build.generate_build_id)"
-          fi
-          echo "build-id: ${build_id}"
-          echo "build-id=${build_id}" >> "$GITHUB_OUTPUT"
+          release_build_id="$(python -m build.generate_build_id)"
+          echo "release-build-id: ${release_build_id}"
+          echo "release-build-id=${release_build_id}" >> "$GITHUB_OUTPUT"
+      - name: Generate Build ID (nightly)
+        if: ${{ (github.event_name == 'workflow_dispatch' && inputs.prerelease) || github.event.release.prerelease }}
+        id: nightly-build-id-generator
+        run: |
+          nightly_build_id="$(python -m build.generate_build_id --pre-release)"
+          echo "nightly-build-id: ${nightly_build_id}"
+          echo "nightly-build-id=${nightly_build_id}" >> "$GITHUB_OUTPUT"
 
   # Phase 2: Build the extension on all platforms.
   build:
@@ -136,22 +146,22 @@ jobs:
       - run: npm ci
 
       # Set the Build ID.
-      - name: Set Build ID
+      - name: Set Build ID (release)
+        if: ${{ (github.event_name == 'workflow_dispatch' && !inputs.prerelease) || !github.event.release.prerelease }}
         run: |
-          if [[ "${{ github.event.release.prerelease }}" = "true" ]]; then
-            python -m build.update_ext_version --build-id ${{ needs.build-id.outputs.build-id }} --for-publishing --pre-release
-          else
-            python -m build.update_ext_version --build-id ${{ needs.build-id.outputs.build-id }} --for-publishing
-          fi
+          python -m build.update_ext_version --build-id ${{ needs.build-id.outputs.release-build-id }} --for-publishing
+      - name: Set Build ID (nightly)
+        if: ${{ (github.event_name == 'workflow_dispatch' && inputs.prerelease) || github.event.release.prerelease }}
+        run: |
+          python -m build.update_ext_version --build-id ${{ needs.build-id.outputs.nightly-build-id }} --for-publishing --pre-release
 
       # Build the extension.
-      - name: Package Extension
-        run: |
-          if [ "${{ github.event.release.prerelease }}" = "true" ]; then
-            npx vsce package -o "./dist/ty-${{ matrix.code-target }}.vsix" --target ${{ matrix.code-target }} --pre-release
-          else
-            npx vsce package -o "./dist/ty-${{ matrix.code-target }}.vsix" --target ${{ matrix.code-target }}
-          fi
+      - name: Package Extension (release)
+        if: ${{ (github.event_name == 'workflow_dispatch' && !inputs.prerelease) || !github.event.release.prerelease }}
+        run: npx vsce package -o "./dist/ty-${{ matrix.code-target }}.vsix" --target ${{ matrix.code-target }}
+      - name: Package Extension (nightly)
+        if: ${{ (github.event_name == 'workflow_dispatch' && inputs.prerelease) || github.event.release.prerelease }}
+        run: npx vsce package -o "./dist/ty-${{ matrix.code-target }}.vsix" --target ${{ matrix.code-target }} --pre-release
 
       # Upload the extension.
       - name: Upload artifacts
@@ -219,13 +229,12 @@ jobs:
       - run: npm ci
 
       # Publish to the Code Marketplace.
-      - name: Publish Extension (Code Marketplace)
-        run: |
-          if [[ "${{ github.event.release.prerelease }}" = "true" ]]; then
-            npx vsce publish --pat ${{ secrets.MARKETPLACE_TOKEN }} --packagePath ./dist/ty-*.vsix --pre-release
-          else
-            npx vsce publish --pat ${{ secrets.MARKETPLACE_TOKEN }} --packagePath ./dist/ty-*.vsix
-          fi
+      - name: Publish Extension (Code Marketplace, release)
+        if: ${{ (github.event_name == 'workflow_dispatch' && !inputs.prerelease) || !github.event.release.prerelease }}
+        run: npx vsce publish --pat ${{ secrets.MARKETPLACE_TOKEN }} --packagePath ./dist/ty-*.vsix
+      - name: Publish Extension (Code Marketplace, nightly)
+        if: ${{ (github.event_name == 'workflow_dispatch' && inputs.prerelease) || github.event.release.prerelease }}
+        run: npx vsce publish --pat ${{ secrets.MARKETPLACE_TOKEN }} --packagePath ./dist/ty-*.vsix --pre-release
 
   publish-openvsx:
     name: "Publish (OpenVSX)"
@@ -285,11 +294,11 @@ jobs:
       - run: npm ci
 
       # Publish to OpenVSX.
-      - name: Publish Extension (OpenVSX)
-        run: |
-          if [[ "${{ github.event.release.prerelease }}" = "true" ]]; then
-            npx ovsx publish --pat ${{ secrets.OPENVSX_TOKEN }} --packagePath ./dist/ty-*.vsix --pre-release
-          else
-            npx ovsx publish --pat ${{ secrets.OPENVSX_TOKEN }} --packagePath ./dist/ty-*.vsix
-          fi
+      - name: Publish Extension (OpenVSX, release)
+        if: ${{ (github.event_name == 'workflow_dispatch' && !inputs.prerelease) || !github.event.release.prerelease }}
+        run: npx ovsx publish --pat ${{ secrets.OPENVSX_TOKEN }} --packagePath ./dist/ty-*.vsix
+        timeout-minutes: 2
+      - name: Publish Extension (OpenVSX, nightly)
+        if: ${{ (github.event_name == 'workflow_dispatch' && inputs.prerelease) || github.event.release.prerelease }}
+        run: npx ovsx publish --pat ${{ secrets.OPENVSX_TOKEN }} --packagePath ./dist/ty-*.vsix --pre-release
         timeout-minutes: 2


### PR DESCRIPTION
## Summary

This PR fixes the release workflow again.

It makes the following changes:
- Take as input for workflow dispatch as to whether this is a stable or prerelease
- Use the `${{ github.event.release.prerelease }}` check under `if` instead of the bash script. This is important because the steps are run in various operating systems where one is Windows which cannot run bash

Regarding the second bullet point, I think this must be the reason that the steps were divided between stable and prerelease workflow and I've reverted back to that structure.

## Test Plan

Going to merge this and manually release.
