### PR TITLE
Use bash shell even for Windows

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -152,12 +152,14 @@ jobs:
       # Set the Build ID.
       - name: Set Build ID (release)
         if: ${{ (github.event_name == 'workflow_dispatch' && !inputs.prerelease) || (github.event_name == 'release' && !github.event.release.prerelease) }}
+        shell: bash
         run: |
           python -m build.update_ext_version --build-id "${BUILD_ID}" --for-publishing
         env:
           BUILD_ID: ${{ needs.build-id.outputs.release-build-id }}
       - name: Set Build ID (nightly)
         if: ${{ (github.event_name == 'workflow_dispatch' && inputs.prerelease) || (github.event_name == 'release' && github.event.release.prerelease) }}
+        shell: bash
         run: |
           python -m build.update_ext_version --build-id "${BUILD_ID}" --for-publishing --pre-release
         env:
@@ -166,9 +168,11 @@ jobs:
       # Build the extension.
       - name: Package Extension (release)
         if: ${{ (github.event_name == 'workflow_dispatch' && !inputs.prerelease) || (github.event_name == 'release' && !github.event.release.prerelease) }}
+        shell: bash
         run: npx vsce package -o "./dist/ty-${{ matrix.code-target }}.vsix" --target ${{ matrix.code-target }}
       - name: Package Extension (nightly)
         if: ${{ (github.event_name == 'workflow_dispatch' && inputs.prerelease) || (github.event_name == 'release' && github.event.release.prerelease) }}
+        shell: bash
         run: npx vsce package -o "./dist/ty-${{ matrix.code-target }}.vsix" --target ${{ matrix.code-target }} --pre-release
 
       # Upload the extension.


### PR DESCRIPTION
This PR fixes a bug found in the latest release failure (https://github.com/astral-sh/ty-vscode/actions/runs/17433796957/job/49498236429) because the environment variable syntax is different for Windows. The fix is to make it use bash consistently.