### PR TITLE
Bump version to 2025.41.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ty",
-  "version": "2025.39.0",
+  "version": "2025.41.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ty",
-      "version": "2025.39.0",
+      "version": "2025.41.0",
       "license": "MIT",
       "dependencies": {
         "@vscode/python-extension": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ty",
   "displayName": "ty",
   "description": "A Visual Studio Code extension with support for the ty type checker and language server.",
-  "version": "2025.39.0",
+  "version": "2025.41.0",
   "serverInfo": {
     "name": "ty",
     "module": "ty"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ty-vscode"
-version = "2025.39.0"
+version = "2025.41.0"
 requires-python = ">=3.8"
 dependencies = ["ty==0.0.1a20"]
 


### PR DESCRIPTION
This is because the last release got published partially (https://github.com/astral-sh/ty-vscode/actions/runs/17435026144/job/49502682516) i.e., 1 of the artifact got published to the marketplace but then it failed with ECONNRESET.