### PR TITLE
Add printDebugInformation command to VSCode extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,12 +73,12 @@ See [settings](https://github.com/astral-sh/ty/blob/main/docs/reference/editor-s
 
 ## Commands
 
-| Command                                          | Description                                     |
-| ------------------------------------------------ | ----------------------------------------------- |
-| ty: Restart server                               | Restart the ty language server                  |
-| ty: Show client logs                             | Open the "ty" output channel                    |
-| ty: Show server logs                             | Open the "ty Language Server" output channel    |
-| ty: Print debug information (native server only) | Print debug information about the native server |
+| Command                    | Description                                  |
+| -------------------------- | -------------------------------------------- |
+| ty: Restart server         | Restart the ty language server               |
+| ty: Show client logs       | Open the "ty" output channel                 |
+| ty: Show server logs       | Open the "ty Language Server" output channel |
+| ty: Open debug information | Opens a window with debug information        |
 
 ## Requirements
 

--- a/package.json
+++ b/package.json
@@ -205,7 +205,7 @@
         "command": "ty.showServerLogs"
       },
       {
-        "title": "Print debug information (native server only)",
+        "title": "Open debug information",
         "category": "ty",
         "command": "ty.debugInformation"
       }

--- a/src/common/settings.ts
+++ b/src/common/settings.ts
@@ -12,39 +12,6 @@ type ImportStrategy = "fromEnvironment" | "useBundled";
 
 type LogLevel = "error" | "warn" | "info" | "debug" | "trace";
 
-type CodeAction = {
-  disableRuleComment?: {
-    enable?: boolean;
-  };
-  fixViolation?: {
-    enable?: boolean;
-  };
-};
-
-type Lint = {
-  enable?: boolean;
-  args?: string[];
-  run?: Run;
-  preview?: boolean;
-  select?: string[];
-  extendSelect?: string[];
-  ignore?: string[];
-};
-
-type Format = {
-  args?: string[];
-  preview?: boolean;
-  backend?: FormatterBackend;
-};
-
-type ConfigPreference = "editorFirst" | "filesystemFirst" | "editorOnly";
-
-type Run = "onType" | "onSave";
-
-type FormatterBackend = "internal" | "uv";
-
-type NativeServer = boolean | "on" | "off" | "auto";
-
 export interface InitializationOptions {
   logLevel?: LogLevel;
   logFile?: string;
@@ -155,28 +122,4 @@ export function checkIfConfigurationChanged(
     `${namespace}.inlayHints`,
   ];
   return settings.some((s) => e.affectsConfiguration(s));
-}
-
-export interface ISettings {
-  nativeServer: NativeServer;
-  cwd: string;
-  workspace: string;
-  path: string[];
-  ignoreStandardLibrary: boolean;
-  interpreter: string[];
-  configuration: string | object | null;
-  importStrategy: ImportStrategy;
-  codeAction: CodeAction;
-  enable: boolean;
-  showNotifications: string;
-  organizeImports: boolean;
-  fixAll: boolean;
-  lint: Lint;
-  format: Format;
-  exclude?: string[];
-  lineLength?: number;
-  configurationPreference?: ConfigPreference;
-  showSyntaxErrors: boolean;
-  logLevel?: LogLevel;
-  logFile?: string;
 }


### PR DESCRIPTION
<!--
Thank you for contributing to ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Hi,
in response of https://github.com/astral-sh/ty-vscode/issues/6 and https://github.com/astral-sh/ty/issues/974, this PR implements a command to see DebugInformation from the ty-server in vs code. As requested, I followed the implementation of ruff-vscode extension for this one.

## Test Plan

I didn't see any tests in the Ruff version so we should discuss if some are needed. But I compiled my version into a `.vsix` file, installed it successfully in VS Code. And after tweaking the ty path to a compiled version of ty from the ruff repo last updates, it works as expected. Similarly to Ruff. 
