### PR TITLE
Add more links to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ Python type checker and language server, written in Rust.
 
 The extension ships with `ty==0.0.1a27`.
 
+## Installation
+
+Install this extension from the [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=astral-sh.ty).
+
 ## Features
 
 Currently, the extension supports the following features:
@@ -38,7 +42,7 @@ Once installed in Visual Studio Code, ty will automatically execute when you ope
 Python or Jupyter Notebook file.
 
 It's recommended to disable the language server from the [Python extension](https://marketplace.visualstudio.com/items?itemName=ms-python.python) to avoid running two Python language servers
-by adding the following [setting](https://code.visualstudio.com/docs/python/settings-reference#_intellisense-engine-settings) to your `settings.json`:
+by adding the following [setting](https://code.visualstudio.com/docs/python/settings-reference#_intellisense-engine-settings) to your [`settings.json`](https://code.visualstudio.com/docs/configure/settings#_settings-json-file):
 
 ```json
 {


### PR DESCRIPTION
## Summary

I decided recently it was finally time to dogfood ty to myself in VSCode. Two things confused me while installing the extension:
- I searched for "ty-vscode" in the marketplace, and no results came up. The reason is that the extension is actually called "ty", not "ty-vscode". I've added a link to the VSCode marketplace so that this is obvious to anybody reading the README.
- The README recommends to edit your `settings.json` file, but I'm a VSCode noob and had no idea how to do that. I've added a link to the `settings.json` reference so that other people in a similar boat don't have to look it up manually
