### PR TITLE
Remove deprecated setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,14 +73,6 @@
   "contributes": {
     "configuration": {
       "properties": {
-        "python.ty.disableLanguageServices": {
-          "default": false,
-          "markdownDescription": "Whether to disable all language services for ty like completions, hover, goto definition, etc.",
-          "markdownDeprecationMessage": "**Deprecated**: Please use `ty.disableLanguageServices` instead.",
-          "deprecationMessage": "Deprecated: Please use ty.disableLanguageServices instead.",
-          "scope": "window",
-          "type": "boolean"
-        },
         "ty.disableLanguageServices": {
           "default": false,
           "markdownDescription": "Whether to disable all language services for ty like completions, hover, goto definition, etc.",


### PR DESCRIPTION
Now that we're close to the beta release, let's remove this (`python.ty.disableLanguageServices`) deprecated setting.