### PR TITLE
Add `python.languageServer` as `None` configuration default

### DIFF
--- a/package.json
+++ b/package.json
@@ -215,7 +215,10 @@
         "category": "ty",
         "command": "ty.debugInformation"
       }
-    ]
+    ],
+    "configurationDefaults": {
+      "python.languageServer": "None"
+    }
   },
   "dependencies": {
     "@vscode/python-extension": "^1.0.5",


### PR DESCRIPTION
<!--
Thank you for contributing to ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Fixes astral-sh/ty#2354

After doing a clean install of basedpyright and noticing the issue wasn't happening, I checked the value of `python.languageServer` and noticed it was `None` instead of the usual default `Default`, but only when I used basedpyright instead of ty.

Searching in their repo for "python.languageServer", I saw they had this entry in their `package.json`:
```json
"configurationDefaults": {
    "python.languageServer": "None",
    "python.analysis.typeCheckingMode": "off",
    "[python]": {
        "editor.formatOnType": true,
        "editor.quickSuggestions": {
            "strings": true
        },
        "editor.wordBasedSuggestions": "off"
    }
},
```

While I'm not sure of what the rest of that does, I think the `"python.languageServer": "None"` is what does the magic, so this PR adds that to ty's `package.json`.

## Test Plan

<!-- How was it tested? -->

I preformed the same clean install steps from astral-sh/ty#2354 , but before I opened the python file I manually updated ty's package.json (in `data\extensions\astral-sh.ty-2026.2.0-win32-x64`) and then observed the bug not happening even though I never touched `python.languageServer` in the VSC settings.