### PR TITLE
docs: version up ty badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ty extension for Visual Studio Code
 
-[![image](https://img.shields.io/pypi/v/ty/0.0.10.svg)](https://pypi.python.org/pypi/ty)
-[![image](https://img.shields.io/pypi/l/ty/0.0.10.svg)](https://pypi.python.org/pypi/ty)
+[![image](https://img.shields.io/pypi/v/ty/0.0.11.svg)](https://pypi.python.org/pypi/ty)
+[![image](https://img.shields.io/pypi/l/ty/0.0.11.svg)](https://pypi.python.org/pypi/ty)
 [![Actions status](https://github.com/astral-sh/ty-vscode/workflows/CI/badge.svg)](https://github.com/astral-sh/ty-vscode/actions)
 
 A Visual Studio Code extension for [ty](https://github.com/astral-sh/ty), an extremely fast


### PR DESCRIPTION
## Summary

Documentation:
- Update PyPI version and license badges in the README to point to version [0.0.11](https://github.com/astral-sh/ty/releases/tag/0.0.11).

## Test Plan

| Diff | Image |
|--------|--------|
| Before | <img width="365" height="40" alt="old" src="https://github.com/user-attachments/assets/659aecd1-1fb0-4c3b-ac5b-fccc991b13fa" /> |
| After | <img width="365" height="42" alt="new" src="https://github.com/user-attachments/assets/41579a9a-3632-473c-93fe-8e54fe3caefe" /> | 