### PR TITLE
Multi-project ty.toml support: one LanguageClient per project

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@vscode/python-extension": "^1.0.5",
         "fs-extra": "^11.3.0",
+        "smol-toml": "^1.6.0",
         "vscode-languageclient": "^9.0.1",
         "which": "^6.0.0"
       },
@@ -7416,6 +7417,17 @@
       },
       "funding": {
         "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/smol-toml": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.0.tgz",
+      "integrity": "sha512-4zemZi0HvTnYwLfrpk/CF9LOd9Lt87kAt50GnqhMpyF9U3poDAP2+iukq2bZsO/ufegbYehBkqINbsWxj4l4cw==",
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/cyyynthia"
       }
     },
     "node_modules/source-map": {

--- a/package.json
+++ b/package.json
@@ -223,6 +223,7 @@
   "dependencies": {
     "@vscode/python-extension": "^1.0.5",
     "fs-extra": "^11.3.0",
+    "smol-toml": "^1.6.0",
     "vscode-languageclient": "^9.0.1",
     "which": "^6.0.0"
   },

--- a/src/client.ts
+++ b/src/client.ts
@@ -40,7 +40,10 @@ interface TyMiddleware extends Middleware {
   setServerVersion(major: number, minor: number, patch: number): void;
 }
 
-export function createTyMiddleware(pythonExtension: PythonExtension): TyMiddleware {
+export function createTyMiddleware(
+  pythonExtension: PythonExtension,
+  configFile?: string,
+): TyMiddleware {
   const didChangeRegistrations = new Set<string>();
   let serverVersion: null | { major: number; minor: number; patch: number } = null;
 
@@ -140,6 +143,8 @@ export function createTyMiddleware(pythonExtension: PythonExtension): TyMiddlewa
                   serverSettings.configurationFile,
                   workspaceFolder,
                 );
+              } else if (configFile && serverSettings.configurationFile == null) {
+                serverSettings.configurationFile = configFile;
               }
 
               return {

--- a/src/common/utilities.ts
+++ b/src/common/utilities.ts
@@ -1,6 +1,8 @@
 import * as fs from "fs-extra";
+import * as os from "os";
 import * as path from "path";
-import { Uri, WorkspaceFolder } from "vscode";
+import { parse as parseToml, stringify as stringifyToml } from "smol-toml";
+import { RelativePattern, Uri, WorkspaceFolder, workspace } from "vscode";
 import { DocumentSelector } from "vscode-languageclient";
 import { getWorkspaceFolders, isVirtualWorkspace } from "./vscodeapi";
 
@@ -32,6 +34,61 @@ export async function getProjectRoot(): Promise<WorkspaceFolder> {
       }
     }
     return rootWorkspace;
+  }
+}
+
+export interface TyProject {
+  configPath: string;
+  projectDir: string;
+}
+
+export async function discoverTyConfigs(wsFolder: WorkspaceFolder): Promise<TyProject[]> {
+  const uris = await workspace.findFiles(new RelativePattern(wsFolder, "**/ty.toml"));
+  return uris
+    .map((uri) => ({ configPath: uri.fsPath, projectDir: path.dirname(uri.fsPath) }))
+    .sort((a, b) => b.projectDir.length - a.projectDir.length);
+}
+
+export function getProjectDocumentSelector(projectDir: string): DocumentSelector {
+  return [{ scheme: "file", language: "python", pattern: `${projectDir}/**` }];
+}
+
+let _tempDir: string | undefined;
+
+export async function writeResolvedConfigFile(configPath: string): Promise<string | undefined> {
+  try {
+    const content = await fs.readFile(configPath, "utf-8");
+    const config = parseToml(content) as Record<string, unknown>;
+    const configDir = path.dirname(configPath);
+
+    const resolvePaths = (vals: unknown): string[] | undefined => {
+      if (!Array.isArray(vals)) return undefined;
+      return vals
+        .filter((v): v is string => typeof v === "string")
+        .map((v) => path.resolve(configDir, v));
+    };
+
+    const env = config["environment"] as Record<string, unknown> | undefined;
+    if (env?.["extra-paths"])
+      env["extra-paths"] = resolvePaths(env["extra-paths"]) ?? env["extra-paths"];
+
+    const src = config["src"] as Record<string, unknown> | undefined;
+    if (src?.["include"]) src["include"] = resolvePaths(src["include"]) ?? src["include"];
+    if (src?.["exclude"]) src["exclude"] = resolvePaths(src["exclude"]) ?? src["exclude"];
+
+    if (!_tempDir) _tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "ty-vscode-"));
+    const tempPath = path.join(_tempDir, configPath.replace(/[^a-zA-Z0-9]/g, "_") + ".toml");
+    await fs.writeFile(tempPath, stringifyToml(config), "utf-8");
+    return tempPath;
+  } catch {
+    return undefined;
+  }
+}
+
+export async function cleanupTempConfigs(): Promise<void> {
+  if (_tempDir) {
+    await fs.remove(_tempDir).catch(() => {});
+    _tempDir = undefined;
   }
 }
 


### PR DESCRIPTION
## Summary

> **Disclaimer:** This PR was developed with assistance from Claude Opus 4.6. I'm opening this because the multi-project support has been extremely useful for my monorepo workflow, but I'm fully open to reworking the approach based on the project's long-term plans for monorepo/multi-project support.

Adds multi-project support for monorepos with multiple `ty.toml` files.

The ty server creates one project per workspace and resolves `extra-paths` relative to the workspace root, not the config file directory. In
monorepos where subdirectories each have their own `ty.toml` with project-specific `extra-paths`, this means paths resolve incorrectly and only one
project can be active at a time.

This PR starts a separate `LanguageClient` per discovered `ty.toml`, each scoped to its project subtree via `documentSelector`. To work around the
path resolution issue, a temporary copy of each `ty.toml` is written with absolute paths and passed as `configurationFile`. A `FileSystemWatcher`
restarts servers when `ty.toml` files are created or deleted.

Adds `smol-toml` as a dependency to parse and rewrite config files with resolved paths.

Ref: https://github.com/astral-sh/ty/issues/693

## Test Plan

Tested in a monorepo with three `ty.toml` files at different directory depths, each with different `extra-paths`:

- Verified each project starts its own server (visible in "ty: Show Logs" output)
- Opened files from two projects side-by-side; each resolves imports from its own `extra-paths`
- Confirmed no `command 'ty.printDebugInformation' already exists` errors (non-primary clients skip `ExecuteCommandFeature` registration)
- Created a new `ty.toml` in a fourth directory; `FileSystemWatcher` detected it and restarted with the new project included
- Deleted a `ty.toml`; servers restarted without the removed project
- Workspace with no `ty.toml` files falls back to a single default server
- `just check` passes (`prettier`, `eslint`, `tsc`)
