### PR TITLE
Handle `ty.runTest` and run tests as tasks

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -4,6 +4,7 @@ import {
   CancellationToken,
   DidChangeConfigurationNotification,
 } from "vscode-languageclient";
+import * as vscode from "vscode";
 import { Uri, workspace } from "vscode";
 import type { PythonExtension } from "@vscode/python-extension";
 import {
@@ -12,6 +13,14 @@ import {
   type ExtensionSettings,
   checkSettingSupported,
 } from "./common/settings";
+import { logger } from "./common/logger";
+
+interface RunTestArgs {
+  cwd: string;
+  program: string;
+  args: string[];
+  test_target: string;
+}
 
 // Keys that are handled by the extension and should not be sent to the server
 type ExtensionOnlyKeys = keyof InitializationOptions | keyof ExtensionSettings | "trace";
@@ -71,6 +80,54 @@ export function createTyMiddleware(pythonExtension: PythonExtension): TyMiddlewa
           didChangeRegistrations.delete(registration.id);
         }
       }
+    },
+
+    async executeCommand(command, args, next) {
+      if (command === "ty.runTest") {
+        const runTest = (args[0] as Record<string, unknown>)?.RunTest as RunTestArgs | undefined;
+        if (runTest == null) {
+          logger.error(
+            "Failed to run test: server sent incomplete arguments",
+            JSON.stringify(args),
+          );
+          vscode.window
+            .showErrorMessage("Failed to run test: missing required arguments.", "Show Logs")
+            .then((selection) => {
+              if (selection) {
+                logger.channel.show();
+              }
+            });
+          return;
+        }
+
+        const { cwd, program, args: programArgs, test_target } = runTest;
+        const task = new vscode.Task(
+          { type: "shell" },
+          vscode.TaskScope.Workspace,
+          `${test_target}`,
+          `ty`,
+          new vscode.ShellExecution(program, programArgs, { cwd }),
+        );
+        task.presentationOptions = {
+          reveal: vscode.TaskRevealKind.Always,
+          panel: vscode.TaskPanelKind.Dedicated,
+          clear: true,
+        };
+        const execution = await vscode.tasks.executeTask(task);
+        await new Promise<void>((resolve) => {
+          const listener = vscode.tasks.onDidEndTaskProcess((e) => {
+            if (e.execution === execution) {
+              listener.dispose();
+              if (e.exitCode !== 0) {
+                logger.error(`Running test failed: ${program} ${programArgs.join(" ")}`);
+              }
+              resolve();
+            }
+          });
+        });
+        return;
+      }
+      return next(command, args);
     },
 
     workspace: {

--- a/src/client.ts
+++ b/src/client.ts
@@ -4,7 +4,6 @@ import {
   CancellationToken,
   DidChangeConfigurationNotification,
 } from "vscode-languageclient";
-import * as vscode from "vscode";
 import { Uri, workspace } from "vscode";
 import type { PythonExtension } from "@vscode/python-extension";
 import {
@@ -13,14 +12,6 @@ import {
   type ExtensionSettings,
   checkSettingSupported,
 } from "./common/settings";
-import { logger } from "./common/logger";
-
-interface RunTestArgs {
-  cwd: string;
-  program: string;
-  args: string[];
-  test_target: string;
-}
 
 // Keys that are handled by the extension and should not be sent to the server
 type ExtensionOnlyKeys = keyof InitializationOptions | keyof ExtensionSettings | "trace";
@@ -80,54 +71,6 @@ export function createTyMiddleware(pythonExtension: PythonExtension): TyMiddlewa
           didChangeRegistrations.delete(registration.id);
         }
       }
-    },
-
-    async executeCommand(command, args, next) {
-      if (command === "ty.runTest") {
-        const runTest = (args[0] as Record<string, unknown>)?.RunTest as RunTestArgs | undefined;
-        if (runTest == null) {
-          logger.error(
-            "Failed to run test: server sent incomplete arguments",
-            JSON.stringify(args),
-          );
-          vscode.window
-            .showErrorMessage("Failed to run test: missing required arguments.", "Show Logs")
-            .then((selection) => {
-              if (selection) {
-                logger.channel.show();
-              }
-            });
-          return;
-        }
-
-        const { cwd, program, args: programArgs, test_target } = runTest;
-        const task = new vscode.Task(
-          { type: "shell" },
-          vscode.TaskScope.Workspace,
-          `${test_target}`,
-          `ty`,
-          new vscode.ShellExecution(program, programArgs, { cwd }),
-        );
-        task.presentationOptions = {
-          reveal: vscode.TaskRevealKind.Always,
-          panel: vscode.TaskPanelKind.Dedicated,
-          clear: true,
-        };
-        const execution = await vscode.tasks.executeTask(task);
-        await new Promise<void>((resolve) => {
-          const listener = vscode.tasks.onDidEndTaskProcess((e) => {
-            if (e.execution === execution) {
-              listener.dispose();
-              if (e.exitCode !== 0) {
-                logger.error(`Running test failed: ${program} ${programArgs.join(" ")}`);
-              }
-              resolve();
-            }
-          });
-        });
-        return;
-      }
-      return next(command, args);
     },
 
     workspace: {

--- a/src/common/commands.ts
+++ b/src/common/commands.ts
@@ -1,7 +1,63 @@
 import * as vscode from "vscode";
 import { ExecuteCommandRequest, LanguageClient } from "vscode-languageclient/node";
+import { logger } from "./logger";
 
 const ISSUE_TRACKER = "https://github.com/astral-sh/ty/issues";
+
+interface RunTestArgs {
+  cwd: string;
+  program: string;
+  arguments: string[];
+  filePath: string;
+  testTarget: string;
+}
+
+/**
+ * Creates a test runner for the `ty.RunTest` command.
+ *
+ * This will run the test in a new terminal.
+ */
+export function createRunTestProvider() {
+  return async (runTest: RunTestArgs | undefined) => {
+    if (runTest == null) {
+      logger.error("Failed to run test: missing 'RunTest' arguments");
+      vscode.window
+        .showErrorMessage("Failed to run test: missing required arguments.", "Show Logs")
+        .then((selection) => {
+          if (selection) {
+            logger.channel.show();
+          }
+        });
+      return;
+    }
+
+    const { cwd, program, arguments: programArgs, testTarget } = runTest;
+    const task = new vscode.Task(
+      { type: "shell" },
+      vscode.TaskScope.Workspace,
+      `${testTarget}`,
+      `ty`,
+      new vscode.ShellExecution(program, programArgs, { cwd }),
+    );
+    task.presentationOptions = {
+      reveal: vscode.TaskRevealKind.Always,
+      panel: vscode.TaskPanelKind.Dedicated,
+      clear: true,
+    };
+    const execution = await vscode.tasks.executeTask(task);
+    await new Promise<void>((resolve) => {
+      const listener = vscode.tasks.onDidEndTaskProcess((e) => {
+        if (e.execution === execution) {
+          listener.dispose();
+          if (e.exitCode !== 0) {
+            logger.error(`Running test failed: ${program} ${programArgs.join(" ")}`);
+          }
+          resolve();
+        }
+      });
+    });
+  };
+}
 
 /**
  * Creates a debug information provider for the `ty.printDebugInformation` command.

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -21,7 +21,7 @@ import {
   onDidGrantWorkspaceTrust,
   registerCommand,
 } from "./common/vscodeapi";
-import { createDebugInformationProvider } from "./common/commands";
+import { createDebugInformationProvider, createRunTestProvider } from "./common/commands";
 
 let lsClient: LanguageClient | undefined;
 let restartInProgress = false;
@@ -58,6 +58,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       `${serverId}.debugInformation`,
       createDebugInformationProvider(getClient, serverId, context),
     ),
+    registerCommand(`${serverId}.runTest`, createRunTestProvider()),
   );
 
   if (restartInProgress) {


### PR DESCRIPTION
<!--
Thank you for contributing to ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Intercept `ty.runTest` command to run tests in a terminal window.
Without this handler the test command would be sent back to server and server runs the test.
See: https://github.com/astral-sh/ruff/pull/24512

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

<!-- How was it tested? -->
