### PR TITLE
Skip searching for ty binary in virtual environment if interpreter is missing or too old

### DIFF
--- a/src/common/python.ts
+++ b/src/common/python.ts
@@ -50,7 +50,7 @@ export async function getInterpreterDetails(resource?: Resource): Promise<IInter
   const environment = await api.environments.resolveEnvironment(
     api.environments.getActiveEnvironmentPath(resource),
   );
-  if (environment?.executable.uri && checkVersion(environment)) {
+  if (environment?.executable.uri) {
     return { path: [environment?.executable.uri.fsPath], resource };
   }
   return { path: undefined, resource };
@@ -71,8 +71,8 @@ export function checkVersion(resolved: ResolvedEnvironment): boolean {
   if (version?.major === 3 && version?.minor >= 8) {
     return true;
   }
-  logger.error(`Python version ${version?.major}.${version?.minor} is not supported.`);
-  logger.error(`Selected python path: ${resolved.executable.uri?.fsPath}`);
-  logger.error("Supported versions are 3.8 and above.");
+  logger.warn(`Python version ${version?.major}.${version?.minor} is not supported.`);
+  logger.warn(`Selected python path: ${resolved.executable.uri?.fsPath}`);
+  logger.warn("Supported versions are 3.8 and above.");
   return false;
 }

--- a/src/common/server.ts
+++ b/src/common/server.ts
@@ -30,7 +30,7 @@ import { getDocumentSelector } from "./utilities";
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 import which = require("which");
 import { createTyMiddleware } from "../client";
-import { getPythonExtensionAPI } from "./python";
+import { checkVersion, getPythonExtensionAPI, resolveInterpreter } from "./python";
 
 /**
  * Check if shell mode is required for `execFile`.
@@ -99,21 +99,40 @@ async function findBinaryPath(settings: ExtensionSettings): Promise<string> {
 
   // Otherwise, we'll call a Python script that tries to locate a binary.
   let tyBinaryPath: string | undefined;
-  try {
-    const stdout = await executeFile(settings.interpreter[0], [FIND_BINARY_SCRIPT_PATH]);
-    tyBinaryPath = stdout.trim();
-  } catch (err) {
-    vscode.window
-      .showErrorMessage(
-        "Unexpected error while trying to find the ty binary. See the logs for more details.",
-        "Show Logs",
-      )
-      .then((selection) => {
-        if (selection) {
-          logger.channel.show();
+
+  if (settings.interpreter.length === 0) {
+    logger.warn(
+      `No interpreter discovered, skip searching for the ty binary in the Python environment.
+To select a Python interpreter, open the command palette and run 'Python: Select Interpreter'.`,
+    );
+  } else {
+    const interpreters = settings.interpreter.join(", ");
+    logger.info(`Using interpreter: ${interpreters}`);
+
+    const resolvedEnvironment = await resolveInterpreter(settings.interpreter);
+
+    if (resolvedEnvironment == null) {
+      logger.warn("Unable to find any Python environment for the interpreter paths:", interpreters);
+    } else {
+      if (checkVersion(resolvedEnvironment)) {
+        try {
+          const stdout = await executeFile(settings.interpreter[0], [FIND_BINARY_SCRIPT_PATH]);
+          tyBinaryPath = stdout.trim();
+        } catch (err) {
+          vscode.window
+            .showErrorMessage(
+              "Unexpected error while trying to find the ty binary. See the logs for more details.",
+              "Show Logs",
+            )
+            .then((selection) => {
+              if (selection) {
+                logger.channel.show();
+              }
+            });
+          logger.error(`Error while trying to find the ty binary: ${err}`);
         }
-      });
-    logger.error(`Error while trying to find the ty binary: ${err}`);
+      }
+    }
   }
 
   if (tyBinaryPath && tyBinaryPath.length > 0) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,12 +1,7 @@
 import * as vscode from "vscode";
 import type { LanguageClient } from "vscode-languageclient/node";
 import { LazyOutputChannel, logger } from "./common/logger";
-import {
-  checkVersion,
-  initializePython,
-  onDidChangePythonInterpreter,
-  resolveInterpreter,
-} from "./common/python";
+import { initializePython, onDidChangePythonInterpreter } from "./common/python";
 import { startServer, stopServer } from "./common/server";
 import {
   checkIfConfigurationChanged,
@@ -14,7 +9,7 @@ import {
   getExtensionSettings,
 } from "./common/settings";
 import { loadServerDefaults } from "./common/setup";
-import { registerLanguageStatusItem, updateStatus } from "./common/status";
+import { registerLanguageStatusItem } from "./common/status";
 import { getProjectRoot } from "./common/utilities";
 import {
   onDidChangeConfiguration,
@@ -92,40 +87,6 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 
       const projectRoot = await getProjectRoot();
       const settings = await getExtensionSettings(serverId, projectRoot);
-
-      if (vscode.workspace.isTrusted) {
-        if (settings.interpreter.length === 0) {
-          updateStatus(
-            vscode.l10n.t("Please select a Python interpreter."),
-            vscode.LanguageStatusSeverity.Error,
-          );
-          logger.error(
-            "Python interpreter missing:\r\n" +
-              "[Option 1] Select Python interpreter using the ms-python.python.\r\n" +
-              `[Option 2] Set an interpreter using "${serverId}.interpreter" setting.\r\n` +
-              "Please use Python 3.8 or greater.",
-          );
-          return;
-        }
-
-        logger.info(`Using interpreter: ${settings.interpreter.join(" ")}`);
-        const resolvedEnvironment = await resolveInterpreter(settings.interpreter);
-        if (resolvedEnvironment === undefined) {
-          updateStatus(
-            vscode.l10n.t("Python interpreter not found."),
-            vscode.LanguageStatusSeverity.Error,
-          );
-          logger.error(
-            "Unable to find any Python environment for the interpreter path:",
-            settings.interpreter.join(" "),
-          );
-          return;
-        }
-
-        if (!checkVersion(resolvedEnvironment)) {
-          return;
-        }
-      }
 
       lsClient = await startServer(
         settings,


### PR DESCRIPTION
## Summary


Today, ty fails to start if no Python interpreter is selected or if the Python version is too old.
I suspect that this is a relict from Ruff's VS Code extension that used Python to run ruff-lsp.

This PR changes the behavior to instead skip discovering the ty binary in the local virtual environment folder if 
the Python interpreter is missing or the Python version is too old. This has the benefit that the extension keeps functioning 
because it can always fallback to the bundled executable.

## Test Plan


When the python version is too old:

```
2026-04-16 15:16:55.500 [info] Using interpreter: /usr/local/bin/python3
2026-04-16 15:16:55.500 [warning] Python version 3.7 is not supported.
2026-04-16 15:16:55.500 [warning] Selected python path: /usr/local/bin/python3
2026-04-16 15:16:55.500 [warning] Supported versions are 3.8 and above.
2026-04-16 15:16:55.506 [info] Falling back to bundled executable: /Users/micha/astral/ty-vscode/bundled/libs/bin/ty
2026-04-16 15:16:55.506 [info] Found executable at /Users/micha/astral/ty-vscode/bundled/libs/bin/ty
2026-04-16 15:16:55.506 [info] Server run command: /Users/micha/astral/ty-vscode/bundled/libs/bin/ty server
2026-04-16 15:16:55.506 [info] Server: Start requested.
2026-04-16 15:16:55.511 [info] ty server version: 0.0.0
```

When no interpreter is selected:

```
2026-04-16 15:21:19.583 [info] Initialization options: {
    "logLevel": "debug"
}
2026-04-16 15:21:19.583 [warning] No interpreter discovered, skip searching for the ty binary in the Python environment.
To select a Python interpreter, open the command palette and run 'Python: Select Interpreter'.
2026-04-16 15:21:19.584 [info] Falling back to bundled executable: /Users/micha/astral/ty-vscode/bundled/libs/bin/ty
2026-04-16 15:21:19.584 [info] Found executable at /Users/micha/astral/ty-vscode/bundled/libs/bin/ty
2026-04-16 15:21:19.584 [info] Server run command: /Users/micha/astral/ty-vscode/bundled/libs/bin/ty server
2026-04-16 15:21:19.584 [info] Server: Start requested.
2026-04-16 15:21:19.590 [info] ty server version: 0.0.0
```

(ignore the weird ty version, that's just because it's using a local debug build)


When an interpreter is selected:

```
2026-04-16 15:25:21.036 [info] Initialization options: {
    "logLevel": "debug"
}
2026-04-16 15:25:21.036 [info] Using interpreter: /Users/micha/astral/venv-test/.venv/bin/python
2026-04-16 15:25:21.056 [info] Using the ty binary: /Users/micha/astral/venv-test/.venv/bin/ty
2026-04-16 15:25:21.056 [info] Found executable at /Users/micha/astral/venv-test/.venv/bin/ty
2026-04-16 15:25:21.056 [info] Server run command: /Users/micha/astral/venv-test/.venv/bin/ty server
2026-04-16 15:25:21.057 [info] Server: Start requested.
2026-04-16 15:25:21.062 [info] ty server version: 0.0.31 (daaa40454 2026-04-15)
```
