### PR TITLE
Avoid unnecessary server restart during initialization

### DIFF
--- a/src/common/python.ts
+++ b/src/common/python.ts
@@ -18,24 +18,45 @@ export async function getPythonExtensionAPI(): Promise<PythonExtension> {
   return api;
 }
 
-export async function initializePython(disposables: Disposable[]): Promise<void> {
+export async function initializePython(
+  disposables: Disposable[],
+): Promise<IInterpreterDetails | undefined> {
+  logger.info("Python extension loading");
+
+  let api;
   try {
-    const api = await getPythonExtensionAPI();
-
-    disposables.push(
-      api.environments.onDidChangeActiveEnvironmentPath((e) => {
-        onDidChangePythonInterpreterEvent.fire({
-          path: [e.path],
-          resource: e.resource,
-        });
-      }),
-    );
-
-    logger.info("Waiting for interpreter from python extension.");
-    onDidChangePythonInterpreterEvent.fire(await getInterpreterDetails());
+    api = await getPythonExtensionAPI();
   } catch (error) {
     logger.error("Error initializing python: ", error);
+    return undefined;
   }
+
+  let currentInterpreter: string | undefined = undefined;
+
+  disposables.push(
+    api.environments.onDidChangeActiveEnvironmentPath((e) => {
+      if (e.path === currentInterpreter) {
+        logger.debug(
+          "Ignoring `onDidChangeActiveEnvironmentPath` event, because the interpreter hasn't changed.",
+        );
+        return;
+      }
+
+      currentInterpreter = e.path;
+      logger.info(`active environment changed to ${e.path}`);
+
+      onDidChangePythonInterpreterEvent.fire({
+        path: [e.path],
+        resource: e.resource,
+      });
+    }),
+  );
+
+  logger.info("Waiting for interpreter from python extension.");
+  const details = await getInterpreterDetails();
+  currentInterpreter = details.path?.[0];
+  logger.info(`Python extension loaded: ${details.path}`);
+  return details;
 }
 
 export async function resolveInterpreter(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -174,10 +174,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     if (vscode.workspace.isTrusted) {
       const interpreter = getInterpreterFromSetting(serverId);
       if (interpreter === undefined || interpreter.length === 0) {
-        logger.info("Python extension loading");
         await initializePython(context.subscriptions);
-        logger.info("Python extension loaded");
-        return; // The `onDidChangePythonInterpreter` event will trigger the server start.
       }
     }
     await runServer();


### PR DESCRIPTION
## Summary

Today, the server is immediately restarted during initialization because the `onDidChangePythonInterpreterEvent` 
gets triggered twice:

1. When `getInterpreterDetails` completes
2. The explicit trigger in `initializePython`


This PR avoids this unnecessary restart by not triggering `onDidChangeActiveEnvironmentPath` before `initializePython` has completed because no code depends on the interpreter at this piont. 


## Test Plan


**main**

```
2026-04-17 12:34:41.835 [info] Name: ty
2026-04-17 12:34:41.835 [info] Module: ty
2026-04-17 12:34:41.835 [info] Python extension loading
2026-04-17 12:34:41.835 [info] Waiting for interpreter from python extension.
2026-04-17 12:34:43.114 [info] Python extension loaded
2026-04-17 12:34:43.115 [info] Using interpreter: /Users/micha/astral/venv-test/.venv/bin/python
2026-04-17 12:34:43.115 [info] Initialization options: {
    "logLevel": "debug"
}
2026-04-17 12:34:43.117 [info] Using 'path' setting: /Users/micha/astral/ruff/target/debug/ty
2026-04-17 12:34:43.119 [info] Found executable at /Users/micha/astral/ruff/target/debug/ty
2026-04-17 12:34:43.121 [info] Server run command: /Users/micha/astral/ruff/target/debug/ty server
2026-04-17 12:34:43.122 [info] Server: Start requested.
2026-04-17 12:34:43.133 [info] Triggered ty restart while restart is in progress; queuing a restart.
2026-04-17 12:34:43.220 [info] ty server version: ruff/0.15.10+57 (f58630f9d 2026-04-16)
2026-04-17 12:34:43.237 [info] Server: Stop requested
2026-04-17 12:34:43.261 [info] Using interpreter: /Users/micha/astral/venv-test/.venv/bin/python
2026-04-17 12:34:43.261 [info] Initialization options: {
    "logLevel": "debug"
}
2026-04-17 12:34:43.262 [info] Using 'path' setting: /Users/micha/astral/ruff/target/debug/ty
2026-04-17 12:34:43.262 [info] Found executable at /Users/micha/astral/ruff/target/debug/ty
2026-04-17 12:34:43.262 [info] Server run command: /Users/micha/astral/ruff/target/debug/ty server
2026-04-17 12:34:43.263 [info] Server: Start requested.
2026-04-17 12:34:43.273 [info] ty server version: ruff/0.15.10+57 (f58630f9d 2026-04-16)
```

**this PR**

```
2026-04-17 12:35:20.114 [info] Name: ty
2026-04-17 12:35:20.114 [info] Module: ty
2026-04-17 12:35:20.114 [info] Python extension loading
2026-04-17 12:35:20.114 [info] Waiting for interpreter from python extension.
2026-04-17 12:35:21.386 [info] Python extension loaded
2026-04-17 12:35:21.387 [info] Using interpreter: /Users/micha/astral/venv-test/.venv/bin/python
2026-04-17 12:35:21.387 [info] Initialization options: {
    "logLevel": "debug"
}
2026-04-17 12:35:21.388 [info] Using 'path' setting: /Users/micha/astral/ruff/target/debug/ty
2026-04-17 12:35:21.390 [info] Found executable at /Users/micha/astral/ruff/target/debug/ty
2026-04-17 12:35:21.390 [info] Server run command: /Users/micha/astral/ruff/target/debug/ty server
2026-04-17 12:35:21.390 [info] Server: Start requested.
2026-04-17 12:35:21.410 [info] ty server version: ruff/0.15.10+57 (f58630f9d 2026-04-16)
```


I verified that changing the interpreter in VS Code continues to trigger a restart.
