### PR TITLE
Merge `python.analysis.extraPaths` into `ty.configuration["environment"]["extra-paths"]`

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,6 +113,12 @@
           "scope": "window",
           "type": "boolean"
         },
+        "ty.forwardExtraPaths": {
+          "default": true,
+          "markdownDescription": "Automatically detect `python.analysis.extraPaths` and merge them into `ty.configuration.environment.extra-paths`.",
+          "scope": "resource",
+          "type": "boolean"
+        },
         "ty.importStrategy": {
           "default": "fromEnvironment",
           "markdownDescription": "Strategy for loading the `ty` executable. `fromEnvironment` picks up ty from the environment, falling back to the bundled version if needed. `useBundled` uses the version bundled with the extension.",

--- a/src/client.ts
+++ b/src/client.ts
@@ -150,7 +150,7 @@ export function createTyMiddleware(pythonExtension: PythonExtension): TyMiddlewa
                   workspace
                     .getConfiguration("python", scopeUri)
                     ?.get<string[]>("analysis.extraPaths") ?? [];
-                if (extraPaths.length > 0 && serverSettings.configuration) {
+                if (extraPaths.length > 0) {
                   const typedSettings: {
                     configuration?: { environment?: { "extra-paths"?: string[] } };
                   } = serverSettings;

--- a/src/client.ts
+++ b/src/client.ts
@@ -146,14 +146,18 @@ export function createTyMiddleware(pythonExtension: PythonExtension): TyMiddlewa
               // Merge python.analysis.extraPaths into ty.configuration["environment"]["extra-paths"]
               // when ty.forwardExtraPaths is enabled (default: true)
               if (result?.forwardExtraPaths) {
-                const extraPaths = workspace.getConfiguration("python", scopeUri)?.get<string[]>("analysis.extraPaths") ?? [];
+                const extraPaths =
+                  workspace
+                    .getConfiguration("python", scopeUri)
+                    ?.get<string[]>("analysis.extraPaths") ?? [];
                 if (extraPaths.length > 0 && serverSettings.configuration) {
-                  const typedSettings: { configuration?: { environment?: { "extra-paths"?: string[]; }; }; } = serverSettings
-                  let a = (((typedSettings
-                    .configuration ??= {})
-                    .environment ??= {})
-                    ["extra-paths"] ??= [])
-                  a.push(...extraPaths)
+                  const typedSettings: {
+                    configuration?: { environment?: { "extra-paths"?: string[] } };
+                  } = serverSettings;
+                  let paths = (((typedSettings.configuration ??= {}).environment ??= {})[
+                    "extra-paths"
+                  ] ??= []);
+                  paths.push(...extraPaths);
                 }
               }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -29,6 +29,7 @@ const EXTENSION_ONLY_KEYS = {
 
   // Client-handled settings
   trace: true,
+  forwardExtraPaths: true,
 } as const satisfies Record<ExtensionOnlyKeys, true>;
 
 function isExtensionOnlyKey(key: string): key is ExtensionOnlyKeys {
@@ -140,6 +141,20 @@ export function createTyMiddleware(pythonExtension: PythonExtension): TyMiddlewa
                   serverSettings.configurationFile,
                   workspaceFolder,
                 );
+              }
+
+              // Merge python.analysis.extraPaths into ty.configuration["environment"]["extra-paths"]
+              // when ty.forwardExtraPaths is enabled (default: true)
+              if (result?.forwardExtraPaths) {
+                const extraPaths = workspace.getConfiguration("python", scopeUri)?.get<string[]>("analysis.extraPaths") ?? [];
+                if (extraPaths.length > 0 && serverSettings.configuration) {
+                  const typedSettings: { configuration?: { environment?: { "extra-paths"?: string[]; }; }; } = serverSettings
+                  let a = (((typedSettings
+                    .configuration ??= {})
+                    .environment ??= {})
+                    ["extra-paths"] ??= [])
+                  a.push(...extraPaths)
+                }
               }
 
               return {

--- a/src/common/settings.ts
+++ b/src/common/settings.ts
@@ -100,6 +100,7 @@ export async function getExtensionSettings(
     path: resolveVariables(config.get<string[]>("path") ?? [], workspace),
     interpreter,
     importStrategy: config.get<ImportStrategy>("importStrategy") ?? "fromEnvironment",
+    forwardExtraPaths: config.get("forwardExtraPaths") ?? true
   };
 }
 

--- a/src/common/settings.ts
+++ b/src/common/settings.ts
@@ -24,6 +24,7 @@ export interface ExtensionSettings {
   path: string[];
   interpreter: string[];
   importStrategy: ImportStrategy;
+  forwardExtraPaths: boolean;
 }
 
 export function resolveVariables(value: string[], workspace?: WorkspaceFolder): string[];


### PR DESCRIPTION


<!--
Thank you for contributing to ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Python dependencies are installed as [editable install](https://setuptools.pypa.io/en/latest/userguide/development_mode.html), which, unfortunately, requires users to manually add them into `extra-paths` to be reachable for typechecker.

This PR adds the ability to read `python.analysis.extraPaths` and merge into `ty.configuration["environment"]["extra-paths"]`, allowing easier migration between language servers.

There's also a new config entry for enabling/disabling such feature

## Test Plan

Test is performed by opening a real-world project in Extension Development Host:
<img width="1337" height="265" alt="image" src="https://github.com/user-attachments/assets/3b02207e-f8a6-4169-ab78-3a94b578dcbf" />

<!-- How was it tested? -->
