### PR TITLE
Fix crash when `python.useEnvironmentsExtension` is set to false

### DIFF
--- a/src/common/python.ts
+++ b/src/common/python.ts
@@ -173,6 +173,15 @@ class PythonEnvironmentExtension implements EnvironmentProvider {
       }
     }
 
+    // The Python Environments extension can return no API when
+    // `python.useEnvironmentsExtension` is false.
+    if (extension.exports == null) {
+      logger.info(
+        "The Python Environments extension is disabled by 'python.useEnvironmentsExtension'.",
+      );
+      return null;
+    }
+
     return new PythonEnvironmentExtension(extension.exports as PythonEnvironmentApi);
   }
 


### PR DESCRIPTION
## Summary

The extension fails to start when using `python.useEnvironmentsExtension=false`, because the Python Environment extension returns
`null` for its API in that case, as Charlie pointed out in his review. I did not address that finding in my original PR
because I interpreted "disabled" as disabling the extension in VS Code, not having the extension active, but "disabled" by using a setting. 

Closes https://github.com/astral-sh/ty-vscode/issues/430

## Test Plan

I verified that the extension fails to start with `python.useEnvironmentsExtension=false`. I verified that the extension falls back to the Python extension provider, when using this branch.
