### PR TITLE
Show links to full ty diagnostics

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,10 @@
 To run the extension, navigate to `src/extension.ts` and run (`F5`). You should see the extension output
 and the language server log messages in the debug console under "ty" and "ty Language Server" respectively.
 
+### Language server protocol extensions
+
+The ty server's experimental Language Server Protocol extensions are documented in the [`ty_server` crate](https://github.com/astral-sh/ruff/blob/main/crates/ty_server/README.md#lsp-extensions).
+
 ### Using a custom version of ty
 
 - Clone [ty](https://github.com/astral-sh/ty) to, e.g., `/home/ferris/ty`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ and the language server log messages in the debug console under "ty" and "ty Lan
 
 ### Language server protocol extensions
 
-The ty server's experimental Language Server Protocol extensions are documented in the [`ty_server` crate](https://github.com/astral-sh/ruff/blob/main/crates/ty_server/README.md#lsp-extensions).
+The ty server's experimental Language Server Protocol extensions are documented in [ty's documentation](https://docs.astral.sh/ty/features/language-server/).
 
 ### Using a custom version of ty
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,5 +1,14 @@
 import {
+  type BaseLanguageClient,
   type Middleware,
+  type ClientCapabilities,
+  type FeatureState,
+  type StaticFeature,
+  DocumentDiagnosticReportKind as ProtocolDocumentDiagnosticReportKind,
+  type WorkspaceDiagnosticReport as ProtocolWorkspaceDiagnosticReport,
+  type WorkspaceDocumentDiagnosticReport as ProtocolWorkspaceDocumentDiagnosticReport,
+  WorkspaceDiagnosticRequest,
+  vsdiag,
   ResponseError,
   CancellationToken,
   DidChangeConfigurationNotification,
@@ -12,6 +21,7 @@ import {
   checkSettingSupported,
 } from "./common/settings";
 import { EnvironmentProvider } from "./common/python";
+import { FullDiagnosticProvider } from "./common/diagnostics";
 
 // Keys that are handled by the extension and should not be sent to the server
 type ExtensionOnlyKeys = keyof InitializationOptions | keyof ExtensionSettings | "trace";
@@ -35,14 +45,117 @@ function isExtensionOnlyKey(key: string): key is ExtensionOnlyKeys {
   return key in EXTENSION_ONLY_KEYS;
 }
 
+export class FullDiagnosticOutputFeature implements StaticFeature {
+  fillClientCapabilities(capabilities: ClientCapabilities): void {
+    capabilities.experimental = {
+      ...capabilities.experimental,
+      // Protocol: https://github.com/astral-sh/ruff/blob/main/crates/ty_server/README.md#full-diagnostic-output
+      fullDiagnosticOutput: true,
+    };
+  }
+
+  initialize(): void {}
+
+  getState(): FeatureState {
+    return { kind: "static" };
+  }
+
+  clear(): void {}
+}
+
 export interface TyMiddleware extends Middleware {
   isDidChangeConfigurationRegistered(): boolean;
   setServerVersion(major: number, minor: number, patch: number): void;
 }
 
-export function createTyMiddleware(environmentProvider: EnvironmentProvider | null): TyMiddleware {
+async function convertWorkspaceDiagnosticReport(
+  client: BaseLanguageClient,
+  fullDiagnosticProvider: FullDiagnosticProvider,
+  report: ProtocolWorkspaceDocumentDiagnosticReport,
+  token: CancellationToken,
+): Promise<{
+  report: vsdiag.WorkspaceDocumentDiagnosticReport;
+  activate?: () => void;
+}> {
+  const uri = client.protocol2CodeConverter.asUri(report.uri);
+  if (report.kind === ProtocolDocumentDiagnosticReportKind.Full) {
+    const items = await client.protocol2CodeConverter.asDiagnostics(report.items, token);
+    return {
+      report: {
+        kind: vsdiag.DocumentDiagnosticReportKind.full,
+        uri,
+        resultId: report.resultId,
+        version: report.version,
+        items,
+      },
+      activate: fullDiagnosticProvider.prepareWorkspaceDiagnostics(uri, items),
+    };
+  }
+
+  return {
+    report: {
+      kind: vsdiag.DocumentDiagnosticReportKind.unChanged,
+      uri,
+      resultId: report.resultId,
+      version: report.version,
+    },
+  };
+}
+
+async function reportWorkspaceDiagnostics(
+  client: BaseLanguageClient,
+  fullDiagnosticProvider: FullDiagnosticProvider,
+  report: ProtocolWorkspaceDiagnosticReport,
+  token: CancellationToken,
+  resultReporter: vsdiag.ResultReporter,
+  isRequestActive: () => boolean,
+): Promise<void> {
+  const items: vsdiag.WorkspaceDocumentDiagnosticReport[] = [];
+  const activations: (() => void)[] = [];
+
+  for (const item of report.items) {
+    if (!isRequestActive()) {
+      return;
+    }
+
+    try {
+      const converted = await convertWorkspaceDiagnosticReport(
+        client,
+        fullDiagnosticProvider,
+        item,
+        token,
+      );
+      items.push(converted.report);
+      if (converted.activate != null) {
+        activations.push(converted.activate);
+      }
+    } catch (error) {
+      if (!isRequestActive()) {
+        return;
+      }
+      client.error("Converting workspace diagnostics failed.", error);
+    }
+  }
+
+  if (!isRequestActive()) {
+    return;
+  }
+
+  for (const activate of activations) {
+    activate();
+  }
+  resultReporter({ items });
+}
+
+export function createTyMiddleware(
+  environmentProvider: EnvironmentProvider | null,
+  fullDiagnosticProvider: FullDiagnosticProvider,
+  getClient: () => BaseLanguageClient | undefined,
+): TyMiddleware {
   const didChangeRegistrations = new Set<string>();
   let serverVersion: null | { major: number; minor: number; patch: number } = null;
+  let nextWorkspaceDiagnosticRequestId = 0;
+  let activeWorkspaceDiagnosticRequestId: number | undefined;
 
   const middleware: TyMiddleware = {
     isDidChangeConfigurationRegistered() {
@@ -70,6 +183,96 @@ export function createTyMiddleware(environmentProvider: EnvironmentProvider | nu
         if (registration.method === DidChangeConfigurationNotification.method) {
           didChangeRegistrations.delete(registration.id);
         }
+      }
+    },
+
+    async handleDiagnostics(uri, diagnostics, next) {
+      fullDiagnosticProvider.updateDiagnostics(uri, diagnostics);
+      return next(uri, diagnostics);
+    },
+
+    async provideDiagnostics(document, previousResultId, token, next) {
+      const report = await next(document, previousResultId, token);
+      if (report?.kind === vsdiag.DocumentDiagnosticReportKind.full) {
+        const uri = document instanceof Uri ? document : document.uri;
+        fullDiagnosticProvider.prepareDocumentDiagnostics(uri, report.items)();
+      }
+      return report;
+    },
+
+    async provideWorkspaceDiagnostics(resultIds, token, resultReporter, next) {
+      const client = getClient();
+      if (client == null) {
+        return next(resultIds, token, resultReporter);
+      }
+      if (!client.isRunning()) {
+        return { items: [] };
+      }
+
+      // vscode-languageclient 9 closes over its original reporter in `next`, so replacing the
+      // reporter cannot decorate workspace diagnostics before its precedence check. Send the
+      // request here and pass the converted reports through the original reporter instead.
+      const requestId = nextWorkspaceDiagnosticRequestId;
+      nextWorkspaceDiagnosticRequestId += 1;
+      activeWorkspaceDiagnosticRequestId = requestId;
+      const partialResultToken = `ty-workspace-diagnostics-${requestId.toString()}`;
+      const isRequestActive = () =>
+        activeWorkspaceDiagnosticRequestId === requestId && !token.isCancellationRequested;
+      const deactivateRequest = () => {
+        if (activeWorkspaceDiagnosticRequestId === requestId) {
+          activeWorkspaceDiagnosticRequestId = undefined;
+        }
+      };
+      let progressQueue = Promise.resolve();
+      const progressDisposable = client.onProgress(
+        WorkspaceDiagnosticRequest.partialResult,
+        partialResultToken,
+        (partialResult) => {
+          progressQueue = progressQueue.then(() =>
+            reportWorkspaceDiagnostics(
+              client,
+              fullDiagnosticProvider,
+              partialResult,
+              token,
+              resultReporter,
+              isRequestActive,
+            ),
+          );
+        },
+      );
+
+      try {
+        const result = await client.sendRequest(
+          WorkspaceDiagnosticRequest.type,
+          {
+            identifier: "ty",
+            previousResultIds: resultIds.map(({ uri, value }) => ({
+              uri: client.code2ProtocolConverter.asUri(uri),
+              value,
+            })),
+            partialResultToken,
+          },
+          token,
+        );
+        await progressQueue;
+
+        await reportWorkspaceDiagnostics(
+          client,
+          fullDiagnosticProvider,
+          result,
+          token,
+          resultReporter,
+          isRequestActive,
+        );
+        return { items: [] };
+      } catch (error) {
+        deactivateRequest();
+        return client.handleFailedRequest(WorkspaceDiagnosticRequest.type, token, error, {
+          items: [],
+        });
+      } finally {
+        deactivateRequest();
+        progressDisposable.dispose();
       }
     },
 

--- a/src/common/diagnostics.ts
+++ b/src/common/diagnostics.ts
@@ -1,0 +1,283 @@
+import * as vscode from "vscode";
+
+export const FULL_DIAGNOSTIC_URI_SCHEME = "ty-diagnostics-view";
+
+const MISSING_DIAGNOSTIC = "Unable to find original ty diagnostic";
+// vscode-languageclient preserves `Diagnostic.data` in its diagnostic collection. Tag prepared
+// reports so reconciliation can distinguish different reports that use the same index-based URI.
+const REPORT_ID_KEY = "__ty_full_diagnostic_report_id";
+
+interface PreparedDiagnostics {
+  readonly reportId: string;
+  readonly sourceKey: string;
+  readonly targets: Map<string, { uri: vscode.Uri; content: string }>;
+}
+
+export class FullDiagnosticProvider
+  implements vscode.TextDocumentContentProvider, vscode.Disposable
+{
+  private readonly onDidChangeEmitter = new vscode.EventEmitter<vscode.Uri>();
+  private readonly contents = new Map<string, string>();
+  private readonly targetsBySource = new Map<string, Set<string>>();
+  private readonly pendingDiagnostics = new Map<string, Map<string, PreparedDiagnostics>>();
+  private reconciliationTimer: ReturnType<typeof setTimeout> | undefined;
+  private nextReportId = 0;
+  private disposed = false;
+  private readonly diagnosticsListener = vscode.languages.onDidChangeDiagnostics(({ uris }) => {
+    this.reconcileDiagnostics(uris);
+  });
+
+  get onDidChange(): vscode.Event<vscode.Uri> {
+    return this.onDidChangeEmitter.event;
+  }
+
+  provideTextDocumentContent(uri: vscode.Uri): string {
+    return this.contents.get(uri.toString()) ?? MISSING_DIAGNOSTIC;
+  }
+
+  updateDiagnostics(sourceUri: vscode.Uri, diagnostics: vscode.Diagnostic[]): void {
+    this.commitDiagnostics(this.prepareDiagnostics(sourceUri, diagnostics, "document"));
+  }
+
+  prepareDocumentDiagnostics(sourceUri: vscode.Uri, diagnostics: vscode.Diagnostic[]): () => void {
+    return this.preparePulledDiagnostics(sourceUri, diagnostics, "document");
+  }
+
+  prepareWorkspaceDiagnostics(sourceUri: vscode.Uri, diagnostics: vscode.Diagnostic[]): () => void {
+    return this.preparePulledDiagnostics(sourceUri, diagnostics, "workspace");
+  }
+
+  private preparePulledDiagnostics(
+    sourceUri: vscode.Uri,
+    diagnostics: vscode.Diagnostic[],
+    origin: "document" | "workspace",
+  ): () => void {
+    const prepared = this.prepareDiagnostics(sourceUri, diagnostics, origin);
+    return () => {
+      let pendingForSource = this.pendingDiagnostics.get(prepared.sourceKey);
+      if (pendingForSource == null) {
+        pendingForSource = new Map();
+        this.pendingDiagnostics.set(prepared.sourceKey, pendingForSource);
+      }
+      pendingForSource.set(prepared.reportId, prepared);
+
+      // Pull middleware runs before vscode-languageclient decides whether to install the report.
+      // Reconcile on the next task so a discarded report never mutates the committed cache. A
+      // workspace report can activate thousands of files at once, so coalesce all pending sources
+      // behind one timer and one read of VS Code's diagnostic collection.
+      this.scheduleReconciliation();
+    };
+  }
+
+  private scheduleReconciliation(): void {
+    if (this.reconciliationTimer != null) {
+      return;
+    }
+
+    this.reconciliationTimer = setTimeout(() => {
+      this.reconciliationTimer = undefined;
+      if (this.disposed || this.pendingDiagnostics.size === 0) {
+        return;
+      }
+
+      const sourceUris = [...this.pendingDiagnostics.keys()].map((source) =>
+        vscode.Uri.parse(source),
+      );
+      this.reconcileDiagnostics(sourceUris, true);
+    }, 0);
+  }
+
+  private reconcileDiagnostics(sourceUris: readonly vscode.Uri[], discardPending = false): void {
+    const linkedDiagnostics = this.linkedDiagnostics(sourceUris);
+
+    for (const sourceUri of sourceUris) {
+      this.reconcileSourceDiagnostics(
+        sourceUri,
+        linkedDiagnostics.get(sourceUri.toString()) ?? new Map(),
+        discardPending,
+      );
+    }
+  }
+
+  private reconcileSourceDiagnostics(
+    sourceUri: vscode.Uri,
+    linkedDiagnostics: Map<string, string | undefined>,
+    discardPending: boolean,
+  ): void {
+    const sourceKey = sourceUri.toString();
+    const pendingForSource = this.pendingDiagnostics.get(sourceKey);
+
+    if (pendingForSource != null) {
+      for (const prepared of pendingForSource.values()) {
+        if (matchesPreparedDiagnostics(linkedDiagnostics, prepared)) {
+          this.pendingDiagnostics.delete(sourceKey);
+          this.commitDiagnostics(prepared);
+          return;
+        }
+      }
+
+      if (discardPending) {
+        this.pendingDiagnostics.delete(sourceKey);
+      }
+    }
+
+    if (linkedDiagnostics.size === 0 && !this.pendingDiagnostics.has(sourceKey)) {
+      this.deleteSource(sourceUri);
+    }
+  }
+
+  private prepareDiagnostics(
+    sourceUri: vscode.Uri,
+    diagnostics: vscode.Diagnostic[],
+    origin: "document" | "workspace",
+  ): PreparedDiagnostics {
+    const reportId = this.nextReportId.toString();
+    this.nextReportId += 1;
+    const sourceKey = sourceUri.toString();
+    const targets = new Map<string, { uri: vscode.Uri; content: string }>();
+
+    diagnostics.forEach((diagnostic, index) => {
+      const data = (diagnostic as unknown as { data?: Record<string, unknown> }).data;
+      if (data == null || typeof data.rendered !== "string") {
+        return;
+      }
+      const rendered = data.rendered;
+      data[REPORT_ID_KEY] = reportId;
+
+      // This mirrors rust-analyzer's index-based URI scheme. Diagnostic indexes are not stable,
+      // so an open document can briefly show stale content while diagnostics are recomputed. In
+      // practice, this is acceptable because `updateDiagnostics` refreshes it with the next report.
+      const target = vscode.Uri.from({
+        scheme: FULL_DIAGNOSTIC_URI_SCHEME,
+        path: `/${origin}/diagnostic message [${index.toString()}]`,
+        fragment: sourceKey,
+        query: index.toString(),
+      });
+      const targetKey = target.toString();
+      const originalCode = diagnostic.code;
+      const documentationUri =
+        typeof originalCode === "object" &&
+        originalCode.target.scheme !== FULL_DIAGNOSTIC_URI_SCHEME
+          ? originalCode.target
+          : undefined;
+      const content = documentationUri
+        ? `${rendered}${rendered.endsWith("\n") ? "\n" : "\n\n"}Documentation: ${documentationUri.toString()}\n`
+        : rendered;
+
+      targets.set(targetKey, { uri: target, content });
+
+      diagnostic.code = {
+        target,
+        value: "Click for full diagnostic",
+      };
+    });
+
+    return { reportId, sourceKey, targets };
+  }
+
+  private commitDiagnostics(prepared: PreparedDiagnostics): void {
+    const { sourceKey, targets } = prepared;
+    const previousTargets = this.targetsBySource.get(sourceKey) ?? new Set<string>();
+    const currentTargets = new Set(targets.keys());
+
+    for (const [targetKey, { uri, content }] of targets) {
+      if (this.contents.get(targetKey) !== content) {
+        this.contents.set(targetKey, content);
+        this.onDidChangeEmitter.fire(uri);
+      }
+    }
+
+    for (const previousTarget of previousTargets) {
+      if (!currentTargets.has(previousTarget)) {
+        this.contents.delete(previousTarget);
+        this.onDidChangeEmitter.fire(vscode.Uri.parse(previousTarget));
+      }
+    }
+
+    if (currentTargets.size > 0) {
+      this.targetsBySource.set(sourceKey, currentTargets);
+    } else {
+      this.targetsBySource.delete(sourceKey);
+    }
+  }
+
+  private linkedDiagnostics(
+    sourceUris: readonly vscode.Uri[],
+  ): Map<string, Map<string, string | undefined>> {
+    const diagnosticsBySource = new Map(
+      sourceUris.map((sourceUri) => [sourceUri.toString(), new Map<string, string | undefined>()]),
+    );
+
+    for (const [sourceUri, diagnostics] of vscode.languages.getDiagnostics()) {
+      const linkedDiagnostics = diagnosticsBySource.get(sourceUri.toString());
+      if (linkedDiagnostics == null) {
+        continue;
+      }
+
+      for (const diagnostic of diagnostics) {
+        if (
+          diagnostic.code != null &&
+          typeof diagnostic.code === "object" &&
+          diagnostic.code.target.scheme === FULL_DIAGNOSTIC_URI_SCHEME
+        ) {
+          const reportId = (diagnostic as unknown as { data?: Record<string, unknown> }).data?.[
+            REPORT_ID_KEY
+          ];
+          linkedDiagnostics.set(
+            diagnostic.code.target.toString(),
+            typeof reportId === "string" ? reportId : undefined,
+          );
+        }
+      }
+    }
+
+    return diagnosticsBySource;
+  }
+
+  private deleteSource(sourceUri: vscode.Uri): void {
+    const sourceKey = sourceUri.toString();
+    this.pendingDiagnostics.delete(sourceKey);
+    const targets = this.targetsBySource.get(sourceKey);
+    if (targets == null) {
+      return;
+    }
+
+    this.targetsBySource.delete(sourceKey);
+    for (const target of targets) {
+      this.contents.delete(target);
+      this.onDidChangeEmitter.fire(vscode.Uri.parse(target));
+    }
+  }
+
+  clear(): void {
+    if (this.reconciliationTimer != null) {
+      clearTimeout(this.reconciliationTimer);
+      this.reconciliationTimer = undefined;
+    }
+
+    const targets = [...this.contents.keys()];
+    this.contents.clear();
+    this.targetsBySource.clear();
+    this.pendingDiagnostics.clear();
+    for (const target of targets) {
+      this.onDidChangeEmitter.fire(vscode.Uri.parse(target));
+    }
+  }
+
+  dispose(): void {
+    this.disposed = true;
+    this.diagnosticsListener.dispose();
+    this.clear();
+    this.onDidChangeEmitter.dispose();
+  }
+}
+
+function matchesPreparedDiagnostics(
+  linkedDiagnostics: Map<string, string | undefined>,
+  prepared: PreparedDiagnostics,
+): boolean {
+  return (
+    linkedDiagnostics.size === prepared.targets.size &&
+    [...prepared.targets].every(([target]) => linkedDiagnostics.get(target) === prepared.reportId)
+  );
+}

--- a/src/common/server.ts
+++ b/src/common/server.ts
@@ -27,7 +27,8 @@ import { getDocumentSelector } from "./utilities";
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 import which = require("which");
-import { createTyMiddleware, type TyMiddleware } from "../client";
+import { createTyMiddleware, FullDiagnosticOutputFeature, type TyMiddleware } from "../client";
+import type { FullDiagnosticProvider } from "./diagnostics";
 import {
   checkInterpreterVersion,
   PythonEnvironmentDetails as PythonEnvironmentDetails,
@@ -250,8 +251,11 @@ async function createServer(
     middleware,
   };
 
+  const client = new LanguageClient(serverId, serverName, serverOptions, clientOptions);
+  client.registerFeature(new FullDiagnosticOutputFeature());
+
   return {
-    client: new LanguageClient(serverId, serverName, serverOptions, clientOptions),
+    client,
     binaryResolution,
     middleware,
   };
@@ -272,13 +276,19 @@ export async function startServer(
   outputChannel: OutputChannel,
   traceOutputChannel: OutputChannel,
   environmentProvider: EnvironmentProvider | null,
+  fullDiagnosticProvider: FullDiagnosticProvider,
 ): Promise<ServerState | null> {
   updateStatus(undefined, LanguageStatusSeverity.Information, true);
 
   const initializationOptions = getInitializationOptions(serverId);
   logger.info(`Initialization options: ${JSON.stringify(initializationOptions, null, 4)}`);
 
-  const middleware = createTyMiddleware(environmentProvider);
+  const clientRef: { current?: LanguageClient } = {};
+  const middleware = createTyMiddleware(
+    environmentProvider,
+    fullDiagnosticProvider,
+    () => clientRef.current,
+  );
 
   const server = await createServer(
     settings,
@@ -290,6 +300,7 @@ export async function startServer(
     environmentProvider,
     middleware,
   );
+  clientRef.current = server.client;
   const newLSClient = server.client;
   logger.info("Starting ty language server.");
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -18,6 +18,7 @@ import {
   registerCommand,
 } from "./common/vscodeapi";
 import { createDebugInformationProvider } from "./common/commands";
+import { FULL_DIAGNOSTIC_URI_SCHEME, FullDiagnosticProvider } from "./common/diagnostics";
 
 let serverState: ServerState | null = null;
 let restartQueued = false;
@@ -48,6 +49,15 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   context.subscriptions.push(traceOutputChannel);
   context.subscriptions.push(logger.channel);
 
+  const fullDiagnosticProvider = new FullDiagnosticProvider();
+  context.subscriptions.push(
+    fullDiagnosticProvider,
+    vscode.workspace.registerTextDocumentContentProvider(
+      FULL_DIAGNOSTIC_URI_SCHEME,
+      fullDiagnosticProvider,
+    ),
+  );
+
   //support for debug command.
   context.subscriptions.push(
     registerCommand(
@@ -63,6 +73,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       await stopServer(serverState.client);
       serverState = null;
     }
+    fullDiagnosticProvider.clear();
 
     const projectRoot = await getProjectRoot();
     const settings = await getExtensionSettings(serverId, projectRoot);
@@ -74,6 +85,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       outputChannel,
       traceOutputChannel,
       environmentProvider,
+      fullDiagnosticProvider,
     );
   };
 


### PR DESCRIPTION
## Summary

This is the ty-vscode companion PR to https://github.com/astral-sh/ruff/pull/26269. See the description on that PR for a full breakdown of the feature and a demo video of it in action.

This was all written and checked by codex. I'm unfamiliar with both TypeScript and writing VSCode extensions, so I didn't even try to review it :-)

## Implementation details (Codex-authored)

Advertise the experimental fullDiagnosticOutput capability and replace the code of each diagnostic for which the server provides full output with a “Click for full diagnostic” link. Back each link with a virtual text document containing the server-rendered plain text. Append any existing rule-documentation URL to that virtual document so replacing the diagnostic code with a link does not hide access to the rule documentation.

Support push, document-pull, and workspace-pull diagnostics. Store rendered contents in the virtual-document provider instead of reading the current diagnostic array by index because pull reports can be rejected by vscode-languageclient result-ID precedence logic. Tag each converted pull report with an extension-local ID, and commit its rendered contents to the cache only after transformed diagnostics for that same ID appear in the VS Code diagnostic collection. This prevents discarded pull results from overwriting current content while retaining the simple index-based virtual URI scheme.

Handle workspace pulls directly in middleware because vscode-languageclient 9 captures its original reporter in a closure; replacing the reporter therefore cannot decorate reports before the library applies its result-ID precedence check. Serialize conversion of workspace-pull partial results, discard results from superseded or cancelled requests, and feed converted reports through the original reporter to preserve the built-in precedence behavior.

Clear cached virtual documents on server restart and extension disposal. Add a link from the extension contributor documentation to the server protocol documentation.

## Test Plan

See https://github.com/astral-sh/ruff/pull/26269