### PR TITLE
Render full diagnostics in color

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@vscode/python-extension": "^1.0.5",
+        "anser": "^2.3.5",
         "fs-extra": "^11.3.0",
         "vscode-languageclient": "^9.0.1",
         "which": "^7.0.0"
@@ -2292,6 +2293,12 @@
       "peerDependencies": {
         "ajv": "^8.8.2"
       }
+    },
+    "node_modules/anser": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/anser/-/anser-2.3.5.tgz",
+      "integrity": "sha512-vcZjxvvVoxTeR5XBNJB38oTu/7eDCZlwdz32N1eNgpyPF7j/Z7Idf+CUwQOkKKpJ7RJyjxgLHCM7vdIK0iCNMQ==",
+      "license": "MIT"
     },
     "node_modules/ansi-escapes": {
       "version": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -225,6 +225,7 @@
   },
   "dependencies": {
     "@vscode/python-extension": "^1.0.5",
+    "anser": "^2.3.5",
     "fs-extra": "^11.3.0",
     "vscode-languageclient": "^9.0.1",
     "which": "^7.0.0"

--- a/src/client.ts
+++ b/src/client.ts
@@ -49,8 +49,10 @@ export class FullDiagnosticOutputFeature implements StaticFeature {
   fillClientCapabilities(capabilities: ClientCapabilities): void {
     capabilities.experimental = {
       ...capabilities.experimental,
-      // Protocol: https://github.com/astral-sh/ruff/blob/main/crates/ty_server/README.md#full-diagnostic-output
+      // Protocol: https://docs.astral.sh/ty/features/language-server/#full-diagnostic-output
       fullDiagnosticOutput: true,
+      // Protocol: https://docs.astral.sh/ty/features/language-server/#colored-diagnostic-output
+      colorDiagnosticOutput: true,
     };
   }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -51,8 +51,6 @@ export class FullDiagnosticOutputFeature implements StaticFeature {
       ...capabilities.experimental,
       // Protocol: https://docs.astral.sh/ty/features/language-server/#full-diagnostic-output
       fullDiagnosticOutput: true,
-      // Protocol: https://docs.astral.sh/ty/features/language-server/#colored-diagnostic-output
-      colorDiagnosticOutput: true,
     };
   }
 

--- a/src/common/diagnostics.ts
+++ b/src/common/diagnostics.ts
@@ -1,6 +1,4 @@
-// `anser` uses TypeScript's `export =` syntax.
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-import Anser = require("anser");
+import Anser from "anser";
 import * as vscode from "vscode";
 
 export const FULL_DIAGNOSTIC_URI_SCHEME = "ty-diagnostics-view";
@@ -97,14 +95,8 @@ export class FullDiagnosticProvider
   }
 
   private decorationType(style: AnsiStyle): vscode.TextEditorDecorationType | undefined {
-    const foreground = FullDiagnosticProvider.toEditorColor(
-      style.foreground,
-      style.foregroundTruecolor,
-    );
-    const background = FullDiagnosticProvider.toEditorColor(
-      style.background,
-      style.backgroundTruecolor,
-    );
+    const foreground = toEditorColor(style.foreground, style.foregroundTruecolor);
+    const background = toEditorColor(style.background, style.backgroundTruecolor);
     const bold = style.decorations.includes("bold");
     const italic = style.decorations.includes("italic");
     const underline = style.decorations.includes("underline");
@@ -127,28 +119,6 @@ export class FullDiagnosticProvider
     }
 
     return decorationType;
-  }
-
-  private static toEditorColor(
-    color: string | null,
-    truecolor: string | null,
-  ): vscode.ThemeColor | string | undefined {
-    if (color == null) {
-      return undefined;
-    }
-
-    if (color === "ansi-truecolor") {
-      return truecolor == null ? undefined : `rgb(${truecolor})`;
-    }
-
-    const paletteColor = /^ansi-palette-(\d+)$/.exec(color)?.[1];
-    if (paletteColor != null) {
-      const rgb = Anser.ansiToJson(`\x1b[38;5;${paletteColor}m`)[1]?.fg;
-      return rgb == null ? undefined : `rgb(${rgb})`;
-    }
-
-    const themeColor = ANSI_THEME_COLORS[color];
-    return themeColor == null ? undefined : new vscode.ThemeColor(themeColor);
   }
 
   updateDiagnostics(sourceUri: vscode.Uri, diagnostics: vscode.Diagnostic[]): void {
@@ -392,6 +362,7 @@ export class FullDiagnosticProvider
   }
 }
 
+const ANSI_PALETTE_COLOR = /^ansi-palette-(\d+)$/;
 const ANSI_THEME_COLORS: Readonly<Record<string, string>> = {
   "ansi-black": "terminal.ansiBlack",
   "ansi-red": "terminal.ansiRed",
@@ -410,6 +381,28 @@ const ANSI_THEME_COLORS: Readonly<Record<string, string>> = {
   "ansi-bright-cyan": "terminal.ansiBrightCyan",
   "ansi-bright-white": "terminal.ansiBrightWhite",
 };
+
+function toEditorColor(
+  color: string | null,
+  truecolor: string | null,
+): vscode.ThemeColor | string | undefined {
+  if (color == null) {
+    return undefined;
+  }
+
+  if (color === "ansi-truecolor") {
+    return truecolor == null ? undefined : `rgb(${truecolor})`;
+  }
+
+  const paletteColor = ANSI_PALETTE_COLOR.exec(color)?.[1];
+  if (paletteColor != null) {
+    const rgb = Anser.ansiToJson(`\x1b[38;5;${paletteColor}m`)[1]?.fg;
+    return rgb == null ? undefined : `rgb(${rgb})`;
+  }
+
+  const themeColor = ANSI_THEME_COLORS[color];
+  return themeColor == null ? undefined : new vscode.ThemeColor(themeColor);
+}
 
 function matchesPreparedDiagnostics(
   linkedDiagnostics: Map<string, string | undefined>,

--- a/src/common/diagnostics.ts
+++ b/src/common/diagnostics.ts
@@ -1,3 +1,6 @@
+// `anser` uses TypeScript's `export =` syntax.
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+import Anser = require("anser");
 import * as vscode from "vscode";
 
 export const FULL_DIAGNOSTIC_URI_SCHEME = "ty-diagnostics-view";
@@ -13,6 +16,14 @@ interface PreparedDiagnostics {
   readonly targets: Map<string, { uri: vscode.Uri; content: string }>;
 }
 
+interface AnsiStyle {
+  readonly foreground: string | null;
+  readonly background: string | null;
+  readonly foregroundTruecolor: string | null;
+  readonly backgroundTruecolor: string | null;
+  readonly decorations: readonly Anser.DecorationName[];
+}
+
 export class FullDiagnosticProvider
   implements vscode.TextDocumentContentProvider, vscode.Disposable
 {
@@ -20,6 +31,7 @@ export class FullDiagnosticProvider
   private readonly contents = new Map<string, string>();
   private readonly targetsBySource = new Map<string, Set<string>>();
   private readonly pendingDiagnostics = new Map<string, Map<string, PreparedDiagnostics>>();
+  private readonly decorationTypes = new Map<string, vscode.TextEditorDecorationType>();
   private reconciliationTimer: ReturnType<typeof setTimeout> | undefined;
   private nextReportId = 0;
   private disposed = false;
@@ -32,7 +44,111 @@ export class FullDiagnosticProvider
   }
 
   provideTextDocumentContent(uri: vscode.Uri): string {
-    return this.contents.get(uri.toString()) ?? MISSING_DIAGNOSTIC;
+    return Anser.ansiToText(this.contents.get(uri.toString()) ?? MISSING_DIAGNOSTIC);
+  }
+
+  applyDecorations(editor: vscode.TextEditor): void {
+    if (editor.document.uri.scheme !== FULL_DIAGNOSTIC_URI_SCHEME) {
+      return;
+    }
+
+    const rangesByDecoration = new Map<vscode.TextEditorDecorationType, vscode.Range[]>();
+    for (const decorationType of this.decorationTypes.values()) {
+      rangesByDecoration.set(decorationType, []);
+    }
+
+    const rendered = this.contents.get(editor.document.uri.toString()) ?? "";
+    let line = 0;
+    let character = 0;
+
+    for (const span of Anser.ansiToJson(rendered, { use_classes: true })) {
+      const style: AnsiStyle = {
+        foreground: span.fg,
+        background: span.bg,
+        foregroundTruecolor: span.fg_truecolor,
+        backgroundTruecolor: span.bg_truecolor,
+        decorations: span.decorations,
+      };
+      const decorationType = this.decorationType(style);
+      const segments = span.content.split("\n");
+
+      for (const [index, segment] of segments.entries()) {
+        if (segment.length > 0 && decorationType != null) {
+          let ranges = rangesByDecoration.get(decorationType);
+          if (ranges == null) {
+            ranges = [];
+            rangesByDecoration.set(decorationType, ranges);
+          }
+          ranges.push(new vscode.Range(line, character, line, character + segment.length));
+        }
+
+        if (index < segments.length - 1) {
+          line += 1;
+          character = 0;
+        } else {
+          character += segment.length;
+        }
+      }
+    }
+
+    for (const [decorationType, ranges] of rangesByDecoration) {
+      editor.setDecorations(decorationType, ranges);
+    }
+  }
+
+  private decorationType(style: AnsiStyle): vscode.TextEditorDecorationType | undefined {
+    const foreground = FullDiagnosticProvider.toEditorColor(
+      style.foreground,
+      style.foregroundTruecolor,
+    );
+    const background = FullDiagnosticProvider.toEditorColor(
+      style.background,
+      style.backgroundTruecolor,
+    );
+    const bold = style.decorations.includes("bold");
+    const italic = style.decorations.includes("italic");
+    const underline = style.decorations.includes("underline");
+
+    if (foreground == null && background == null && !bold && !italic && !underline) {
+      return undefined;
+    }
+
+    const key = JSON.stringify(style);
+    let decorationType = this.decorationTypes.get(key);
+    if (decorationType == null) {
+      decorationType = vscode.window.createTextEditorDecorationType({
+        color: foreground,
+        backgroundColor: background,
+        fontWeight: bold ? "bold" : undefined,
+        fontStyle: italic ? "italic" : undefined,
+        textDecoration: underline ? "underline" : undefined,
+      });
+      this.decorationTypes.set(key, decorationType);
+    }
+
+    return decorationType;
+  }
+
+  private static toEditorColor(
+    color: string | null,
+    truecolor: string | null,
+  ): vscode.ThemeColor | string | undefined {
+    if (color == null) {
+      return undefined;
+    }
+
+    if (color === "ansi-truecolor") {
+      return truecolor == null ? undefined : `rgb(${truecolor})`;
+    }
+
+    const paletteColor = /^ansi-palette-(\d+)$/.exec(color)?.[1];
+    if (paletteColor != null) {
+      const rgb = Anser.ansiToJson(`\x1b[38;5;${paletteColor}m`)[1]?.fg;
+      return rgb == null ? undefined : `rgb(${rgb})`;
+    }
+
+    const themeColor = ANSI_THEME_COLORS[color];
+    return themeColor == null ? undefined : new vscode.ThemeColor(themeColor);
   }
 
   updateDiagnostics(sourceUri: vscode.Uri, diagnostics: vscode.Diagnostic[]): void {
@@ -269,8 +385,31 @@ export class FullDiagnosticProvider
     this.diagnosticsListener.dispose();
     this.clear();
     this.onDidChangeEmitter.dispose();
+    for (const decorationType of this.decorationTypes.values()) {
+      decorationType.dispose();
+    }
+    this.decorationTypes.clear();
   }
 }
+
+const ANSI_THEME_COLORS: Readonly<Record<string, string>> = {
+  "ansi-black": "terminal.ansiBlack",
+  "ansi-red": "terminal.ansiRed",
+  "ansi-green": "terminal.ansiGreen",
+  "ansi-yellow": "terminal.ansiYellow",
+  "ansi-blue": "terminal.ansiBlue",
+  "ansi-magenta": "terminal.ansiMagenta",
+  "ansi-cyan": "terminal.ansiCyan",
+  "ansi-white": "terminal.ansiWhite",
+  "ansi-bright-black": "terminal.ansiBrightBlack",
+  "ansi-bright-red": "terminal.ansiBrightRed",
+  "ansi-bright-green": "terminal.ansiBrightGreen",
+  "ansi-bright-yellow": "terminal.ansiBrightYellow",
+  "ansi-bright-blue": "terminal.ansiBrightBlue",
+  "ansi-bright-magenta": "terminal.ansiBrightMagenta",
+  "ansi-bright-cyan": "terminal.ansiBrightCyan",
+  "ansi-bright-white": "terminal.ansiBrightWhite",
+};
 
 function matchesPreparedDiagnostics(
   linkedDiagnostics: Map<string, string | undefined>,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -51,6 +51,10 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 
   const fullDiagnosticProvider = new FullDiagnosticProvider();
   const decorateVisibleEditors = (document: vscode.TextDocument) => {
+    if (document.uri.scheme !== FULL_DIAGNOSTIC_URI_SCHEME) {
+      return;
+    }
+
     for (const editor of vscode.window.visibleTextEditors) {
       if (editor.document === document) {
         fullDiagnosticProvider.applyDecorations(editor);
@@ -64,12 +68,6 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       fullDiagnosticProvider,
     ),
     vscode.workspace.onDidChangeTextDocument(({ document }) => decorateVisibleEditors(document)),
-    vscode.workspace.onDidOpenTextDocument(decorateVisibleEditors),
-    vscode.window.onDidChangeActiveTextEditor((editor) => {
-      if (editor != null) {
-        fullDiagnosticProvider.applyDecorations(editor);
-      }
-    }),
     vscode.window.onDidChangeVisibleTextEditors((editors) => {
       for (const editor of editors) {
         fullDiagnosticProvider.applyDecorations(editor);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -50,12 +50,31 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   context.subscriptions.push(logger.channel);
 
   const fullDiagnosticProvider = new FullDiagnosticProvider();
+  const decorateVisibleEditors = (document: vscode.TextDocument) => {
+    for (const editor of vscode.window.visibleTextEditors) {
+      if (editor.document === document) {
+        fullDiagnosticProvider.applyDecorations(editor);
+      }
+    }
+  };
   context.subscriptions.push(
     fullDiagnosticProvider,
     vscode.workspace.registerTextDocumentContentProvider(
       FULL_DIAGNOSTIC_URI_SCHEME,
       fullDiagnosticProvider,
     ),
+    vscode.workspace.onDidChangeTextDocument(({ document }) => decorateVisibleEditors(document)),
+    vscode.workspace.onDidOpenTextDocument(decorateVisibleEditors),
+    vscode.window.onDidChangeActiveTextEditor((editor) => {
+      if (editor != null) {
+        fullDiagnosticProvider.applyDecorations(editor);
+      }
+    }),
+    vscode.window.onDidChangeVisibleTextEditors((editors) => {
+      for (const editor of editors) {
+        fullDiagnosticProvider.applyDecorations(editor);
+      }
+    }),
   );
 
   //support for debug command.


### PR DESCRIPTION
## Context

This builds on the original **Click for full diagnostic** feature implemented in [astral-sh/ruff#26269](https://github.com/astral-sh/ruff/pull/26269) and [astral-sh/ty-vscode#462](https://github.com/astral-sh/ty-vscode/pull/462). The colored rendering follows the approach established by [rust-lang/rust-analyzer#13848](https://github.com/rust-lang/rust-analyzer/pull/13848).

## Summary

- strip ANSI sequences from the virtual document and recreate their styles with VS Code decorations
- support named terminal colors, 256-color palette entries, truecolor, and text decorations

## Companion PRs

- [astral-sh/ruff#26384](https://github.com/astral-sh/ruff/pull/26384)
- [astral-sh/ty#3858](https://github.com/astral-sh/ty/pull/3858)

## Test plan


https://github.com/user-attachments/assets/36638263-fe48-4ba7-8abe-95db353f1257

