### PR TITLE
Restore diagnostic code in VS Code diagnostics

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -13,7 +13,7 @@ import {
   CancellationToken,
   DidChangeConfigurationNotification,
 } from "vscode-languageclient";
-import { Uri, workspace } from "vscode";
+import { CodeActionTriggerKind, Uri, workspace } from "vscode";
 import {
   resolveVariables,
   type InitializationOptions,
@@ -198,6 +198,20 @@ export function createTyMiddleware(
         fullDiagnosticProvider.prepareDocumentDiagnostics(uri, report.items)();
       }
       return report;
+    },
+
+    async provideCodeActions(document, range, context, token, next) {
+      const actions = await next(document, range, context, token);
+      if (context.triggerKind !== CodeActionTriggerKind.Invoke) {
+        return actions;
+      }
+
+      const fullDiagnosticActions = fullDiagnosticProvider.createCodeActions(context.diagnostics);
+      if (fullDiagnosticActions.length === 0) {
+        return actions;
+      }
+
+      return [...(actions ?? []), ...fullDiagnosticActions];
     },
 
     async provideWorkspaceDiagnostics(resultIds, token, resultReporter, next) {

--- a/src/common/diagnostics.ts
+++ b/src/common/diagnostics.ts
@@ -161,7 +161,8 @@ export class FullDiagnosticProvider
 
     diagnostics.forEach((diagnostic, index) => {
       const data = (diagnostic as unknown as { data?: Record<string, unknown> }).data;
-      if (data == null || typeof data.rendered !== "string") {
+      const originalCode = diagnostic.code;
+      if (data == null || typeof data.rendered !== "string" || originalCode == null) {
         return;
       }
       const rendered = data.rendered;
@@ -177,7 +178,6 @@ export class FullDiagnosticProvider
         query: index.toString(),
       });
       const targetKey = target.toString();
-      const originalCode = diagnostic.code;
       const originalCodeValue =
         typeof originalCode === "object" ? originalCode.value : originalCode;
       const documentationUri =
@@ -193,7 +193,7 @@ export class FullDiagnosticProvider
 
       diagnostic.code = {
         target,
-        value: originalCodeValue ?? "Click for full diagnostic",
+        value: originalCodeValue,
       };
     });
 

--- a/src/common/diagnostics.ts
+++ b/src/common/diagnostics.ts
@@ -47,6 +47,29 @@ export class FullDiagnosticProvider
     return this.preparePulledDiagnostics(sourceUri, diagnostics, "workspace");
   }
 
+  createCodeActions(diagnostics: readonly vscode.Diagnostic[]): vscode.CodeAction[] {
+    return diagnostics.flatMap((diagnostic) => {
+      const code = diagnostic.code;
+      if (
+        code == null ||
+        typeof code !== "object" ||
+        code.target.scheme !== FULL_DIAGNOSTIC_URI_SCHEME
+      ) {
+        return [];
+      }
+
+      const title = "ty: Show full diagnostic";
+      const action = new vscode.CodeAction(title, vscode.CodeActionKind.QuickFix);
+      action.diagnostics = [diagnostic];
+      action.command = {
+        command: "vscode.open",
+        title,
+        arguments: [code.target],
+      };
+      return [action];
+    });
+  }
+
   private preparePulledDiagnostics(
     sourceUri: vscode.Uri,
     diagnostics: vscode.Diagnostic[],
@@ -155,6 +178,8 @@ export class FullDiagnosticProvider
       });
       const targetKey = target.toString();
       const originalCode = diagnostic.code;
+      const originalCodeValue =
+        typeof originalCode === "object" ? originalCode.value : originalCode;
       const documentationUri =
         typeof originalCode === "object" &&
         originalCode.target.scheme !== FULL_DIAGNOSTIC_URI_SCHEME
@@ -168,7 +193,7 @@ export class FullDiagnosticProvider
 
       diagnostic.code = {
         target,
-        value: "Click for full diagnostic",
+        value: originalCodeValue ?? "Click for full diagnostic",
       };
     });
 


### PR DESCRIPTION
## Summary

Restore the diagnostic codes in the VS Code diagnostic pop up and problems panel. The diagnostic code is a fairly important bit of information that we should not hide behind a "Show full diagnostic" link. This PR restores it by showing the code instead of the "Show full diagnostic" label. 

This PR also adds a code action *ty: Show full diagnostic* to make this easier discoverable. 

We could consider reverting the link on the diagnostic to always go to the documentation. It feels more consistent to me, but it makes the feature more difficult to discover. 

If we decide to remove the click action from the code, we could then move the entire implementation into the LSP, by creating the action server side. It also avoids the need for rendering every diagnostic in full during the diagnostic request. Instead, it can be lazily computed in the code action handler (rendering all diagnostics in a 10k diagnostic workspace can be expensive!). The only downside it has is that a client that is capable of showing the full diagnostic inline would no longer be able to do so.

Closes https://github.com/astral-sh/ty/issues/3891

## Test Plan

https://github.com/user-attachments/assets/30d1d335-f7a3-4e5a-92b9-13ba086dab21


