### PR TITLE
ty.triggerParameterHints capability and register handler

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -63,6 +63,30 @@ export class FullDiagnosticOutputFeature implements StaticFeature {
   clear(): void {}
 }
 
+/**
+ * Advertises support for the `ty.triggerParameterHints` completion command,
+ * which the extension executes by triggering VS Code's built-in parameter
+ * hints after a callable completion inserts its parentheses.
+ */
+export class TriggerParameterHintsFeature implements StaticFeature {
+  fillClientCapabilities(capabilities: ClientCapabilities): void {
+    capabilities.experimental = {
+      ...capabilities.experimental,
+      commands: {
+        commands: ["ty.triggerParameterHints"],
+      },
+    };
+  }
+
+  initialize(): void {}
+
+  getState(): FeatureState {
+    return { kind: "static" };
+  }
+
+  clear(): void {}
+}
+
 export interface TyMiddleware extends Middleware {
   isDidChangeConfigurationRegistered(): boolean;
   setServerVersion(major: number, minor: number, patch: number): void;

--- a/src/common/server.ts
+++ b/src/common/server.ts
@@ -27,7 +27,12 @@ import { getDocumentSelector } from "./utilities";
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 import which = require("which");
-import { createTyMiddleware, FullDiagnosticOutputFeature, type TyMiddleware } from "../client";
+import {
+  createTyMiddleware,
+  FullDiagnosticOutputFeature,
+  TriggerParameterHintsFeature,
+  type TyMiddleware,
+} from "../client";
 import type { FullDiagnosticProvider } from "./diagnostics";
 import {
   checkInterpreterVersion,
@@ -253,6 +258,7 @@ async function createServer(
 
   const client = new LanguageClient(serverId, serverName, serverOptions, clientOptions);
   client.registerFeature(new FullDiagnosticOutputFeature());
+  client.registerFeature(new TriggerParameterHintsFeature());
 
   return {
     client,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -86,9 +86,15 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   // Executes the `ty.triggerParameterHints` completion command by delegating
   // to VS Code's built-in parameter hints action.
   context.subscriptions.push(
-    registerCommand("ty.triggerParameterHints", () =>
-      vscode.commands.executeCommand("editor.action.triggerParameterHints"),
-    ),
+    registerCommand("ty.triggerParameterHints", async () => {
+      const parameterHintsEnabled = vscode.workspace
+        .getConfiguration("editor")
+        .get<boolean>("parameterHints.enabled");
+
+      if (parameterHintsEnabled) {
+        await vscode.commands.executeCommand("editor.action.triggerParameterHints");
+      }
+    }),
   );
 
   const environmentProvider = await getEnvironmentProvider();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -83,6 +83,14 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     ),
   );
 
+  // Executes the `ty.triggerParameterHints` completion command by delegating
+  // to VS Code's built-in parameter hints action.
+  context.subscriptions.push(
+    registerCommand("ty.triggerParameterHints", () =>
+      vscode.commands.executeCommand("editor.action.triggerParameterHints"),
+    ),
+  );
+
   const environmentProvider = await getEnvironmentProvider();
 
   const runServer = async () => {


### PR DESCRIPTION
Send the experimental.commands.commands capability during initialize so the ty server attaches the completion command, and register a handler that delegates to VS Code's built-in editor.action.triggerParameterHints.

<!--
Thank you for contributing to ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

To fix [astral-sh/ty#4063 ](https://github.com/astral-sh/ty/issues/4063). As a accompanying fix of [astral-sh/ruff #27084 ](https://github.com/astral-sh/ruff/pull/27084)

## Test Plan

<!-- How was it tested? -->

1. Video compares the effect. Fixed vs before fixing.


https://github.com/user-attachments/assets/f9de5526-4c9d-46a0-8262-0c12ecf71991


2. It won't panic when ty-bin's version is newer than vscode-extension. Vice versa