### PR TITLE
Upgrade vscode-languageclient to v10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,13 +12,13 @@
         "@vscode/python-extension": "^1.0.5",
         "anser": "^2.3.5",
         "fs-extra": "^11.3.0",
-        "vscode-languageclient": "^9.0.1",
+        "vscode-languageclient": "^10.1.0",
         "which": "^7.0.0"
       },
       "devDependencies": {
         "@types/fs-extra": "^11.0.4",
         "@types/node": "^24.0.0",
-        "@types/vscode": "1.75.0",
+        "@types/vscode": "1.91.0",
         "@types/which": "^3.0.4",
         "@typescript/native": "npm:typescript@^7.0.2",
         "@vscode/python-environments": "^1.0.0",
@@ -36,7 +36,7 @@
         "webpack-cli": "^7.0.0"
       },
       "engines": {
-        "vscode": "^1.75.0"
+        "vscode": "^1.91.0"
       }
     },
     "node_modules/@azu/format-text": {
@@ -1851,9 +1851,9 @@
       "license": "MIT"
     },
     "node_modules/@types/vscode": {
-      "version": "1.75.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.75.0.tgz",
-      "integrity": "sha512-SAr0PoOhJS6FUq5LjNr8C/StBKALZwDVm3+U4pjF/3iYkt3GioJOPV/oB1Sf1l7lROe4TgrMyL5N1yaEgTWycw==",
+      "version": "1.91.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.91.0.tgz",
+      "integrity": "sha512-PgPr+bUODjG3y+ozWUCyzttqR9EHny9sPAfJagddQjDwdtf66y2sDKJMnFZRuzBA2YtBGASqJGPil8VDUPvO6A==",
       "dev": true,
       "license": "MIT"
     },
@@ -3399,10 +3399,13 @@
       }
     },
     "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "license": "MIT"
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -3480,12 +3483,15 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -5928,7 +5934,6 @@
       "version": "10.2.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
       "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "brace-expansion": "^5.0.5"
@@ -5938,29 +5943,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/minimatch/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/minimatch/node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "20 || >=22"
       }
     },
     "node_modules/minimist": {
@@ -7063,9 +7045,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -8005,54 +7987,49 @@
       }
     },
     "node_modules/vscode-jsonrpc": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
-      "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-9.0.1.tgz",
+      "integrity": "sha512-rfuA6T75H6m5EkbhtEPzre9pT0HPcDI2MMy4+nPFIBks5J8JBAUHD4tRYSgaBOijIEC7SRkC1kKyXTLqbmh9jw==",
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/vscode-languageclient": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-9.0.1.tgz",
-      "integrity": "sha512-JZiimVdvimEuHh5olxhxkht09m3JzUGwggb5eRUkzzJhZ2KjCN0nh55VfiED9oez9DyF8/fz1g1iBV3h+0Z2EA==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-10.1.0.tgz",
+      "integrity": "sha512-XXRx6lqVitQy/oOLr9MfNYRG+MbQkhXkDaxbQMiKxEm8zZNfheRFUKNb8UYNh2stn9btl2wQM5wZFJjJvoc+jA==",
       "license": "MIT",
       "dependencies": {
-        "minimatch": "^5.1.0",
-        "semver": "^7.3.7",
-        "vscode-languageserver-protocol": "3.17.5"
+        "minimatch": "^10.2.5",
+        "semver": "^7.8.1",
+        "vscode-languageserver-protocol": "3.18.2",
+        "vscode-languageserver-textdocument": "1.0.13"
       },
       "engines": {
-        "vscode": "^1.82.0"
-      }
-    },
-    "node_modules/vscode-languageclient/node_modules/minimatch": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
+        "vscode": "^1.91.0"
       }
     },
     "node_modules/vscode-languageserver-protocol": {
-      "version": "3.17.5",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
-      "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
+      "version": "3.18.2",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.18.2.tgz",
+      "integrity": "sha512-XRyDbT0Pp3sSNti3JmxVEUMySWCSi1hhM+/KUlCy1hV1zmrqpM1OwO12EAki8blhmLuIMpaJrYbo0OzGVfK2Qg==",
       "license": "MIT",
       "dependencies": {
-        "vscode-jsonrpc": "8.2.0",
-        "vscode-languageserver-types": "3.17.5"
+        "vscode-jsonrpc": "9.0.1",
+        "vscode-languageserver-types": "3.18.0"
       }
     },
+    "node_modules/vscode-languageserver-textdocument": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.13.tgz",
+      "integrity": "sha512-nx0ZHwMGIsVkzFG3/VLeJYBLTaFBRuNdGDvevvjuoayU5EOS2fEYazOhtCM3PI9ClMMg5igc0uwXtAq4tJj+Dw==",
+      "license": "MIT"
+    },
     "node_modules/vscode-languageserver-types": {
-      "version": "3.17.5",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
-      "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.18.0.tgz",
+      "integrity": "sha512-8TsGPNMIMiiBdkORgRSvLjuiEIiAFtO+KssmYWxQ+uSVvlf7RjK8YKCOjPzZ+YA04jXEV7+7LvkSmHkhpNS99g==",
       "license": "MIT"
     },
     "node_modules/watchpack": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "ty"
   ],
   "engines": {
-    "vscode": "^1.75.0"
+    "vscode": "^1.91.0"
   },
   "categories": [
     "Programming Languages"
@@ -227,13 +227,13 @@
     "@vscode/python-extension": "^1.0.5",
     "anser": "^2.3.5",
     "fs-extra": "^11.3.0",
-    "vscode-languageclient": "^9.0.1",
+    "vscode-languageclient": "^10.1.0",
     "which": "^7.0.0"
   },
   "devDependencies": {
     "@types/fs-extra": "^11.0.4",
     "@types/node": "^24.0.0",
-    "@types/vscode": "1.75.0",
+    "@types/vscode": "1.91.0",
     "@types/which": "^3.0.4",
     "@typescript/native": "npm:typescript@^7.0.2",
     "@vscode/python-environments": "^1.0.0",

--- a/src/client.ts
+++ b/src/client.ts
@@ -4,7 +4,9 @@ import {
   type ClientCapabilities,
   type FeatureState,
   type StaticFeature,
+  type DiagnosticRegistrationOptions,
   DocumentDiagnosticReportKind as ProtocolDocumentDiagnosticReportKind,
+  DocumentDiagnosticRequest,
   type WorkspaceDiagnosticReport as ProtocolWorkspaceDiagnosticReport,
   type WorkspaceDocumentDiagnosticReport as ProtocolWorkspaceDocumentDiagnosticReport,
   WorkspaceDiagnosticRequest,
@@ -22,6 +24,7 @@ import {
 } from "./common/settings";
 import { EnvironmentProvider } from "./common/python";
 import { FullDiagnosticProvider } from "./common/diagnostics";
+import { getDocumentSelector } from "./common/utilities";
 
 // Keys that are handled by the extension and should not be sent to the server
 type ExtensionOnlyKeys = keyof InitializationOptions | keyof ExtensionSettings | "trace";
@@ -191,6 +194,46 @@ export function createTyMiddleware(
     },
 
     async handleRegisterCapability(params, next) {
+      for (const registration of params.registrations) {
+        if (registration.method !== DocumentDiagnosticRequest.method) {
+          continue;
+        }
+
+        const options = registration.registerOptions as DiagnosticRegistrationOptions | undefined;
+        if (options?.documentSelector != null) {
+          continue;
+        }
+
+        // Patch the `documentDiagnostic` server capapbility and remove `vscode-notebook-cell` to
+        // prevent the VSCode language server client V10 from calling `pullDiagnostic` for
+        // cell text-documents.
+        //
+        // We do this for two reasons:
+        //
+        // ty versions older than ~Aug 15th 2026 panicked when `pullDiagnostic` was called with
+        // a cell text-document. Disabling `pullDiagnostic` for notebook cells ensures backwards
+        // compatibility with these older binaries.
+        //
+        // To workaround the following two upstream issues, by preferring `pushDiagnostic`s for notebook cells:
+        // * https://github.com/microsoft/vscode-languageserver-node/issues/1837
+        // * and, partially, https://github.com/microsoft/vscode-languageserver-node/issues/1836
+        //
+        // Once the  upstream issues are fixed, make this registration conditional based on a client/server negogiated
+        // capability:
+        //
+        // * Introduce a new experimental ty-specific `notebookPullDiagnostic` capability. Clients with
+        //   a recent enough VS Code language client version set the capability in the initializeRequest
+        // * New servers supporting pull diagnostics for cells announce the same `notebookPullDiagnostic` capability
+        //   if the client signaled support
+        // * The client changes the registration here based on whether the server sent the `notebookPullDiagnostic` capability.
+        registration.registerOptions = {
+          ...options,
+          documentSelector: getDocumentSelector().filter(
+            (filter) => filter.scheme !== "vscode-notebook-cell",
+          ),
+        };
+      }
+
       await next(params, CancellationToken.None);
 
       for (const registration of params.registrations) {

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,15 +1,10 @@
 import {
-  type BaseLanguageClient,
   type Middleware,
   type ClientCapabilities,
   type FeatureState,
   type StaticFeature,
   type DiagnosticRegistrationOptions,
-  DocumentDiagnosticReportKind as ProtocolDocumentDiagnosticReportKind,
   DocumentDiagnosticRequest,
-  type WorkspaceDiagnosticReport as ProtocolWorkspaceDiagnosticReport,
-  type WorkspaceDocumentDiagnosticReport as ProtocolWorkspaceDocumentDiagnosticReport,
-  WorkspaceDiagnosticRequest,
   vsdiag,
   ResponseError,
   CancellationToken,
@@ -95,94 +90,12 @@ export interface TyMiddleware extends Middleware {
   setServerVersion(major: number, minor: number, patch: number): void;
 }
 
-async function convertWorkspaceDiagnosticReport(
-  client: BaseLanguageClient,
-  fullDiagnosticProvider: FullDiagnosticProvider,
-  report: ProtocolWorkspaceDocumentDiagnosticReport,
-  token: CancellationToken,
-): Promise<{
-  report: vsdiag.WorkspaceDocumentDiagnosticReport;
-  activate?: () => void;
-}> {
-  const uri = client.protocol2CodeConverter.asUri(report.uri);
-  if (report.kind === ProtocolDocumentDiagnosticReportKind.Full) {
-    const items = await client.protocol2CodeConverter.asDiagnostics(report.items, token);
-    return {
-      report: {
-        kind: vsdiag.DocumentDiagnosticReportKind.full,
-        uri,
-        resultId: report.resultId,
-        version: report.version,
-        items,
-      },
-      activate: fullDiagnosticProvider.prepareWorkspaceDiagnostics(uri, items),
-    };
-  }
-
-  return {
-    report: {
-      kind: vsdiag.DocumentDiagnosticReportKind.unChanged,
-      uri,
-      resultId: report.resultId,
-      version: report.version,
-    },
-  };
-}
-
-async function reportWorkspaceDiagnostics(
-  client: BaseLanguageClient,
-  fullDiagnosticProvider: FullDiagnosticProvider,
-  report: ProtocolWorkspaceDiagnosticReport,
-  token: CancellationToken,
-  resultReporter: vsdiag.ResultReporter,
-  isRequestActive: () => boolean,
-): Promise<void> {
-  const items: vsdiag.WorkspaceDocumentDiagnosticReport[] = [];
-  const activations: (() => void)[] = [];
-
-  for (const item of report.items) {
-    if (!isRequestActive()) {
-      return;
-    }
-
-    try {
-      const converted = await convertWorkspaceDiagnosticReport(
-        client,
-        fullDiagnosticProvider,
-        item,
-        token,
-      );
-      items.push(converted.report);
-      if (converted.activate != null) {
-        activations.push(converted.activate);
-      }
-    } catch (error) {
-      if (!isRequestActive()) {
-        return;
-      }
-      client.error("Converting workspace diagnostics failed.", error);
-    }
-  }
-
-  if (!isRequestActive()) {
-    return;
-  }
-
-  for (const activate of activations) {
-    activate();
-  }
-  resultReporter({ items });
-}
-
 export function createTyMiddleware(
   environmentProvider: EnvironmentProvider | null,
   fullDiagnosticProvider: FullDiagnosticProvider,
-  getClient: () => BaseLanguageClient | undefined,
 ): TyMiddleware {
   const didChangeRegistrations = new Set<string>();
   let serverVersion: null | { major: number; minor: number; patch: number } = null;
-  let nextWorkspaceDiagnosticRequestId = 0;
-  let activeWorkspaceDiagnosticRequestId: number | undefined;
 
   const middleware: TyMiddleware = {
     isDidChangeConfigurationRegistered() {
@@ -281,80 +194,20 @@ export function createTyMiddleware(
       return [...(actions ?? []), ...fullDiagnosticActions];
     },
 
-    async provideWorkspaceDiagnostics(resultIds, token, resultReporter, next) {
-      const client = getClient();
-      if (client == null) {
-        return next(resultIds, token, resultReporter);
-      }
-      if (!client.isRunning()) {
-        return { items: [] };
-      }
-
-      // vscode-languageclient 9 closes over its original reporter in `next`, so replacing the
-      // reporter cannot decorate workspace diagnostics before its precedence check. Send the
-      // request here and pass the converted reports through the original reporter instead.
-      const requestId = nextWorkspaceDiagnosticRequestId;
-      nextWorkspaceDiagnosticRequestId += 1;
-      activeWorkspaceDiagnosticRequestId = requestId;
-      const partialResultToken = `ty-workspace-diagnostics-${requestId.toString()}`;
-      const isRequestActive = () =>
-        activeWorkspaceDiagnosticRequestId === requestId && !token.isCancellationRequested;
-      const deactivateRequest = () => {
-        if (activeWorkspaceDiagnosticRequestId === requestId) {
-          activeWorkspaceDiagnosticRequestId = undefined;
+    provideWorkspaceDiagnostics(resultIds, token, resultReporter, next) {
+      return next(resultIds, token, (report) => {
+        if (token.isCancellationRequested) {
+          return;
         }
-      };
-      let progressQueue = Promise.resolve();
-      const progressDisposable = client.onProgress(
-        WorkspaceDiagnosticRequest.partialResult,
-        partialResultToken,
-        (partialResult) => {
-          progressQueue = progressQueue.then(() =>
-            reportWorkspaceDiagnostics(
-              client,
-              fullDiagnosticProvider,
-              partialResult,
-              token,
-              resultReporter,
-              isRequestActive,
-            ),
-          );
-        },
-      );
 
-      try {
-        const result = await client.sendRequest(
-          WorkspaceDiagnosticRequest.type,
-          {
-            identifier: "ty",
-            previousResultIds: resultIds.map(({ uri, value }) => ({
-              uri: client.code2ProtocolConverter.asUri(uri),
-              value,
-            })),
-            partialResultToken,
-          },
-          token,
-        );
-        await progressQueue;
+        for (const item of report?.items ?? []) {
+          if (item.kind === vsdiag.DocumentDiagnosticReportKind.full) {
+            fullDiagnosticProvider.prepareWorkspaceDiagnostics(item.uri, item.items)();
+          }
+        }
 
-        await reportWorkspaceDiagnostics(
-          client,
-          fullDiagnosticProvider,
-          result,
-          token,
-          resultReporter,
-          isRequestActive,
-        );
-        return { items: [] };
-      } catch (error) {
-        deactivateRequest();
-        return client.handleFailedRequest(WorkspaceDiagnosticRequest.type, token, error, {
-          items: [],
-        });
-      } finally {
-        deactivateRequest();
-        progressDisposable.dispose();
-      }
+        resultReporter(report);
+      });
     },
 
     workspace: {

--- a/src/common/logger.ts
+++ b/src/common/logger.ts
@@ -3,12 +3,6 @@ import * as vscode from "vscode";
 
 const GROUP_INDENT = "  ";
 const MAX_LEVEL_LABEL_LENGTH = "[warning]".length;
-const TRACE_TIMESTAMP_FORMATTER = new Intl.DateTimeFormat(undefined, {
-  hour: "2-digit",
-  minute: "2-digit",
-  second: "2-digit",
-  hourCycle: "h23",
-});
 
 type LogLevel = "error" | "warning" | "info" | "debug" | "trace";
 
@@ -161,20 +155,22 @@ export function createServerOutputChannel(name: string): vscode.LogOutputChannel
 export class LazyOutputChannel implements vscode.LogOutputChannel {
   name: string;
   _channel: vscode.OutputChannel | undefined;
-  private readonly logLevelEmitter = new vscode.EventEmitter<vscode.LogLevel>();
-  readonly onDidChangeLogLevel = this.logLevelEmitter.event;
-  private readonly configurationSubscription: vscode.Disposable;
+  readonly onDidChangeLogLevel: vscode.Event<vscode.LogLevel> = (listener, thisArgs, disposables) =>
+    vscode.workspace.onDidChangeConfiguration(
+      (event) => {
+        if (event.affectsConfiguration(`${this.serverId}.trace.server`)) {
+          listener.call(thisArgs, this.logLevel);
+        }
+      },
+      undefined,
+      disposables,
+    );
 
   constructor(
     name: string,
     private readonly serverId: string,
   ) {
     this.name = name;
-    this.configurationSubscription = vscode.workspace.onDidChangeConfiguration((event) => {
-      if (event.affectsConfiguration(`${serverId}.trace.server`)) {
-        this.logLevelEmitter.fire(this.logLevel);
-      }
-    });
   }
 
   get logLevel(): vscode.LogLevel {
@@ -190,28 +186,17 @@ export class LazyOutputChannel implements vscode.LogOutputChannel {
     return this._channel;
   }
 
-  trace(message: string, ...args: any[]): void {
+  trace = this.log;
+  debug = this.log;
+  info = this.log;
+  warn = this.log;
+  error = this.log;
+
+  private log(message: string | Error, ...args: any[]): void {
     const now = new Date();
     const milliseconds = now.getMilliseconds().toString().padStart(3, "0");
-    this.channel.appendLine(
-      `[${TRACE_TIMESTAMP_FORMATTER.format(now)}.${milliseconds}] ${util.format(message, ...args)}`,
-    );
-  }
-
-  debug(message: string, ...args: any[]): void {
-    this.channel.appendLine(util.format(message, ...args));
-  }
-
-  info(message: string, ...args: any[]): void {
-    this.channel.appendLine(util.format(message, ...args));
-  }
-
-  warn(message: string, ...args: any[]): void {
-    this.channel.appendLine(util.format(message, ...args));
-  }
-
-  error(error: string | Error, ...args: any[]): void {
-    this.channel.appendLine(util.format(error, ...args));
+    const time = `${now.toLocaleTimeString("en-GB")}.${milliseconds}`;
+    this.channel.appendLine(`[${time}] ${util.format(message, ...args)}`);
   }
 
   append(value: string): void {
@@ -241,8 +226,6 @@ export class LazyOutputChannel implements vscode.LogOutputChannel {
   }
 
   dispose(): void {
-    this.configurationSubscription.dispose();
-    this.logLevelEmitter.dispose();
     this._channel?.dispose();
   }
 }

--- a/src/common/logger.ts
+++ b/src/common/logger.ts
@@ -3,6 +3,12 @@ import * as vscode from "vscode";
 
 const GROUP_INDENT = "  ";
 const MAX_LEVEL_LABEL_LENGTH = "[warning]".length;
+const TRACE_TIMESTAMP_FORMATTER = new Intl.DateTimeFormat(undefined, {
+  hour: "2-digit",
+  minute: "2-digit",
+  second: "2-digit",
+  hourCycle: "h23",
+});
 
 type LogLevel = "error" | "warning" | "info" | "debug" | "trace";
 
@@ -106,6 +112,40 @@ function indentMessage(indent: string, message: string): string {
 export const logger = new ExtensionLogger();
 
 /**
+ * Creates an unformatted server output channel that satisfies the language client's log API.
+ *
+ * ty already includes timestamps and severity in its logs, so adding VS Code's log formatting
+ * would duplicate both and incorrectly label every stderr message as an error. The language
+ * client forwards server stderr through `error`; recognize server log levels so client errors
+ * and lifecycle messages still go to the client log.
+ */
+export function createServerOutputChannel(name: string): vscode.LogOutputChannel {
+  const channel = vscode.window.createOutputChannel(name, "log");
+
+  return {
+    ...channel,
+    get logLevel(): vscode.LogLevel {
+      return vscode.env.logLevel;
+    },
+    onDidChangeLogLevel: vscode.env.onDidChangeLogLevel,
+    trace: logger.trace.bind(logger),
+    debug: logger.debug.bind(logger),
+    info: logger.info.bind(logger),
+    warn: logger.warn.bind(logger),
+    error(error: string | Error, ...args: any[]): void {
+      const message = util.format(error, ...args);
+      // The language client sends both server logs and client errors here. Server logs
+      // include a log level and must keep their original format.
+      if (/\b(trace|debug|info|warn|error)\b/i.test(message)) {
+        channel.appendLine(message);
+      } else {
+        logger.error(message);
+      }
+    },
+  };
+}
+
+/**
  * A VS Code output channel that is lazily created when it is first accessed.
  *
  * This is useful when the messages are only logged when the extension is configured
@@ -113,20 +153,65 @@ export const logger = new ExtensionLogger();
  *
  * This is currently being used to create the trace output channel for the language server
  * as it is only created when the user enables trace logging.
+ *
+ * The language client only enables tracing when the channel reports the trace log level. Use
+ * the server trace setting for that level so changing the setting does not require a separate
+ * editor log-level change.
  */
-export class LazyOutputChannel implements vscode.OutputChannel {
+export class LazyOutputChannel implements vscode.LogOutputChannel {
   name: string;
   _channel: vscode.OutputChannel | undefined;
+  private readonly logLevelEmitter = new vscode.EventEmitter<vscode.LogLevel>();
+  readonly onDidChangeLogLevel = this.logLevelEmitter.event;
+  private readonly configurationSubscription: vscode.Disposable;
 
-  constructor(name: string) {
+  constructor(
+    name: string,
+    private readonly serverId: string,
+  ) {
     this.name = name;
+    this.configurationSubscription = vscode.workspace.onDidChangeConfiguration((event) => {
+      if (event.affectsConfiguration(`${serverId}.trace.server`)) {
+        this.logLevelEmitter.fire(this.logLevel);
+      }
+    });
+  }
+
+  get logLevel(): vscode.LogLevel {
+    return vscode.workspace.getConfiguration(this.serverId).get("trace.server", "off") === "off"
+      ? vscode.LogLevel.Info
+      : vscode.LogLevel.Trace;
   }
 
   get channel(): vscode.OutputChannel {
     if (!this._channel) {
-      this._channel = vscode.window.createOutputChannel(this.name);
+      this._channel = vscode.window.createOutputChannel(this.name, "log");
     }
     return this._channel;
+  }
+
+  trace(message: string, ...args: any[]): void {
+    const now = new Date();
+    const milliseconds = now.getMilliseconds().toString().padStart(3, "0");
+    this.channel.appendLine(
+      `[${TRACE_TIMESTAMP_FORMATTER.format(now)}.${milliseconds}] ${util.format(message, ...args)}`,
+    );
+  }
+
+  debug(message: string, ...args: any[]): void {
+    this.channel.appendLine(util.format(message, ...args));
+  }
+
+  info(message: string, ...args: any[]): void {
+    this.channel.appendLine(util.format(message, ...args));
+  }
+
+  warn(message: string, ...args: any[]): void {
+    this.channel.appendLine(util.format(message, ...args));
+  }
+
+  error(error: string | Error, ...args: any[]): void {
+    this.channel.appendLine(util.format(error, ...args));
   }
 
   append(value: string): void {
@@ -156,6 +241,8 @@ export class LazyOutputChannel implements vscode.OutputChannel {
   }
 
   dispose(): void {
+    this.configurationSubscription.dispose();
+    this.logLevelEmitter.dispose();
     this._channel?.dispose();
   }
 }

--- a/src/common/logger.ts
+++ b/src/common/logger.ts
@@ -196,6 +196,7 @@ export class LazyOutputChannel implements vscode.LogOutputChannel {
     const now = new Date();
     const milliseconds = now.getMilliseconds().toString().padStart(3, "0");
     const time = `${now.toLocaleTimeString("en-GB")}.${milliseconds}`;
+    // All protocol messages have the same severity, so do not include it in the output.
     this.channel.appendLine(`[${time}] ${util.format(message, ...args)}`);
   }
 

--- a/src/common/server.ts
+++ b/src/common/server.ts
@@ -289,12 +289,7 @@ export async function startServer(
   const initializationOptions = getInitializationOptions(serverId);
   logger.info(`Initialization options: ${JSON.stringify(initializationOptions, null, 4)}`);
 
-  const clientRef: { current?: LanguageClient } = {};
-  const middleware = createTyMiddleware(
-    environmentProvider,
-    fullDiagnosticProvider,
-    () => clientRef.current,
-  );
+  const middleware = createTyMiddleware(environmentProvider, fullDiagnosticProvider);
 
   const server = await createServer(
     settings,
@@ -306,7 +301,6 @@ export async function startServer(
     environmentProvider,
     middleware,
   );
-  clientRef.current = server.client;
   const newLSClient = server.client;
   logger.info("Starting ty language server.");
 

--- a/src/common/server.ts
+++ b/src/common/server.ts
@@ -2,7 +2,7 @@ import * as fsapi from "fs-extra";
 import { execFile } from "node:child_process";
 import { platform } from "node:os";
 import * as vscode from "vscode";
-import { type Disposable, l10n, LanguageStatusSeverity, type OutputChannel } from "vscode";
+import { type Disposable, l10n, LanguageStatusSeverity, type LogOutputChannel } from "vscode";
 import {
   type LanguageClientOptions,
   MessageType,
@@ -226,8 +226,8 @@ async function createServer(
   settings: ExtensionSettings,
   serverId: string,
   serverName: string,
-  outputChannel: OutputChannel,
-  traceOutputChannel: OutputChannel,
+  outputChannel: LogOutputChannel,
+  traceOutputChannel: LogOutputChannel,
   initializationOptions: InitializationOptions,
   environmentProvider: EnvironmentProvider | null,
   middleware: TyMiddleware,
@@ -279,8 +279,8 @@ export async function startServer(
   settings: ExtensionSettings,
   serverId: string,
   serverName: string,
-  outputChannel: OutputChannel,
-  traceOutputChannel: OutputChannel,
+  outputChannel: LogOutputChannel,
+  traceOutputChannel: LogOutputChannel,
   environmentProvider: EnvironmentProvider | null,
   fullDiagnosticProvider: FullDiagnosticProvider,
 ): Promise<ServerState | null> {

--- a/src/common/utilities.ts
+++ b/src/common/utilities.ts
@@ -1,7 +1,6 @@
 import * as fs from "fs-extra";
 import * as path from "path";
 import { Uri, WorkspaceFolder } from "vscode";
-import { DocumentSelector } from "vscode-languageclient";
 import { getWorkspaceFolders, isVirtualWorkspace } from "./vscodeapi";
 
 export async function getProjectRoot(): Promise<WorkspaceFolder> {
@@ -35,7 +34,7 @@ export async function getProjectRoot(): Promise<WorkspaceFolder> {
   }
 }
 
-export function getDocumentSelector(): DocumentSelector {
+export function getDocumentSelector(): { language: string; scheme?: string }[] {
   return isVirtualWorkspace()
     ? [{ language: "python" }]
     : [

--- a/src/common/vscodeapi.ts
+++ b/src/common/vscodeapi.ts
@@ -5,13 +5,13 @@ import {
   commands,
   ConfigurationScope,
   Disposable,
+  DocumentSelector,
   languages,
   LanguageStatusItem,
   workspace,
   WorkspaceConfiguration,
   WorkspaceFolder,
 } from "vscode";
-import { DocumentSelector } from "vscode-languageclient";
 
 export function getConfiguration(
   config: string,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,7 +1,7 @@
 import * as vscode from "vscode";
 import type { LanguageClient } from "vscode-languageclient/node";
 import { DidChangeConfigurationNotification } from "vscode-languageclient";
-import { LazyOutputChannel, logger } from "./common/logger";
+import { createServerOutputChannel, LazyOutputChannel, logger } from "./common/logger";
 import {
   getEnvironmentProvider,
   onDidChangeActivePythonEnvironment,
@@ -41,8 +41,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   logger.debug(`Full Server Info: ${JSON.stringify(serverInfo)}`);
 
   // Create output channels for the server and trace logs
-  const outputChannel = vscode.window.createOutputChannel(`${serverName} Language Server`);
-  const traceOutputChannel = new LazyOutputChannel(`${serverName} Language Server Trace`);
+  const outputChannel = createServerOutputChannel(`${serverName} Language Server`);
+  const traceOutputChannel = new LazyOutputChannel(`${serverName} Language Server Trace`, serverId);
 
   // Make sure that these channels are disposed when the extension is deactivated.
   context.subscriptions.push(outputChannel);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,9 +6,6 @@
     "sourceMap": true,
     "rootDir": "src",
     "strict": true,
-    // Workaround for a type error within `vscode-jsonrpc`.
-    // See https://github.com/microsoft/vscode-languageserver-node/issues/1590
-    "skipLibCheck": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "noUnusedParameters": true,


### PR DESCRIPTION
## Summary

This PR upgrades the `vscode-languageclient` to v10. This will allow us to use (the supported) LSP 3.18 features in VS Code. 

The main changes are:

* We now need to pass `LogOutputChannel`s. This requires a bit working around that API
* v10 starts to pull diagnostics for notebook cell documents. We need to disable this behavior for older ty versions and to work around two upstream bugs. I wrote a lengthy inline comment explaining the why and what we should do once the upstream issues are fixed.

Closes https://github.com/astral-sh/ty/issues/3772
Closes https://github.com/astral-sh/ty/issues/4276

## Test Plan

https://github.com/user-attachments/assets/316e1dee-196f-46b1-be0c-57afcd94f98f




https://github.com/user-attachments/assets/e653be20-671e-4870-9a69-9f624ff107b2

