### PR TITLE
Add `experimental.useUv` setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,6 @@ For untrusted workspaces, the extension always uses the bundled ty executable, i
 - [`ty.interpreter`](https://docs.astral.sh/ty/reference/editor-settings#interpreter)
 - [`ty.path`](https://docs.astral.sh/ty/reference/editor-settings#path)
 
-The extension also turns off uv integration in untrusted workspaces.
-
 ## Settings
 
 See the ty [editor settings reference](https://docs.astral.sh/ty/reference/editor-settings/) for an enumeration of all supported settings.

--- a/README.md
+++ b/README.md
@@ -61,8 +61,10 @@ in VS code.
 ## Untrusted Workspace
 
 The extension supports [untrusted workspace](https://code.visualstudio.com/docs/editor/workspace-trust).
-For untrusted workspaces, the extension always uses the bundled ty executable, ignoring the following settings:
+For untrusted workspaces, the extension always uses the bundled ty executable and disables uv integration,
+ignoring the following settings:
 
+- `ty.experimental.useUv`
 - [`ty.importStrategy`](https://docs.astral.sh/ty/reference/editor-settings#importstrategy)
 - [`ty.interpreter`](https://docs.astral.sh/ty/reference/editor-settings#interpreter)
 - [`ty.path`](https://docs.astral.sh/ty/reference/editor-settings#path)

--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ For untrusted workspaces, the extension always uses the bundled ty executable, i
 - [`ty.interpreter`](https://docs.astral.sh/ty/reference/editor-settings#interpreter)
 - [`ty.path`](https://docs.astral.sh/ty/reference/editor-settings#path)
 
+The extension also turns off uv integration in untrusted workspaces.
+
 ## Settings
 
 See the ty [editor settings reference](https://docs.astral.sh/ty/reference/editor-settings/) for an enumeration of all supported settings.

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
       "restrictedConfigurations": [
         "ty.experimental.useUv",
         "ty.importStrategy",
-        "ty.interpreter"
+        "ty.interpreter",
+        "ty.path"
       ]
     },
     "virtualWorkspaces": {

--- a/package.json
+++ b/package.json
@@ -105,6 +105,22 @@
           "scope": "window",
           "type": "string"
         },
+        "ty.experimental.useUv": {
+          "default": "off",
+          "markdownDescription": "Control how ty uses uv. This setting is always off in untrusted workspaces.",
+          "enum": [
+            "off",
+            "scripts",
+            "on"
+          ],
+          "enumDescriptions": [
+            "Do not use uv.",
+            "Use uv to create environments for standalone scripts.",
+            "Use uv to find projects and create environments for standalone scripts."
+          ],
+          "scope": "window",
+          "type": "string"
+        },
         "ty.showSyntaxErrors": {
           "default": true,
           "markdownDescription": "Whether to show syntax error diagnostics.",

--- a/package.json
+++ b/package.json
@@ -108,6 +108,22 @@
           "scope": "window",
           "type": "string"
         },
+        "ty.experimental.useUv": {
+          "default": "off",
+          "markdownDescription": "Control how ty uses uv. This setting is always off in untrusted workspaces.",
+          "enum": [
+            "off",
+            "scripts",
+            "on"
+          ],
+          "enumDescriptions": [
+            "Do not use uv.",
+            "Use uv to create environments for standalone scripts.",
+            "Use uv to find projects and create environments for standalone scripts."
+          ],
+          "scope": "window",
+          "type": "string"
+        },
         "ty.showSyntaxErrors": {
           "default": true,
           "markdownDescription": "Whether to show syntax error diagnostics.",

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
         },
         "ty.experimental.useUv": {
           "default": "off",
-          "markdownDescription": "Control how ty uses uv. This setting is always off in untrusted workspaces.",
+          "markdownDescription": "Control how ty uses uv.",
           "enum": [
             "off",
             "scripts",

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
           "type": "string"
         },
         "ty.experimental.useUv": {
-          "default": "off",
+          "default": null,
           "markdownDescription": "Control how ty uses uv.",
           "enum": [
             "off",

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
         },
         "ty.experimental.useUv": {
           "default": "off",
-          "markdownDescription": "Control how ty uses uv. This setting is always off in untrusted workspaces.",
+          "markdownDescription": "Control how ty uses uv.",
           "enum": [
             "off",
             "scripts",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
       "restrictedConfigurations": [
         "ty.experimental.useUv",
         "ty.importStrategy",
-        "ty.interpreter"
+        "ty.interpreter",
+        "ty.path"
       ]
     },
     "virtualWorkspaces": {

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
           "type": "string"
         },
         "ty.experimental.useUv": {
-          "default": "off",
+          "default": null,
           "markdownDescription": "Control how ty uses uv.",
           "enum": [
             "off",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "untrustedWorkspaces": {
       "supported": "limited",
       "restrictedConfigurations": [
+        "ty.experimental.useUv",
         "ty.importStrategy",
         "ty.interpreter"
       ]

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "untrustedWorkspaces": {
       "supported": "limited",
       "restrictedConfigurations": [
+        "ty.experimental.useUv",
         "ty.importStrategy",
         "ty.interpreter"
       ]

--- a/src/client.ts
+++ b/src/client.ts
@@ -22,7 +22,8 @@ import { FullDiagnosticProvider } from "./common/diagnostics";
 import { getDocumentSelector } from "./common/utilities";
 
 // Keys that are handled by the extension and should not be sent to the server
-type ExtensionOnlyKeys = keyof InitializationOptions | keyof ExtensionSettings | "trace";
+type ExtensionOnlyKeys =
+  Exclude<keyof InitializationOptions, "experimental"> | keyof ExtensionSettings | "trace";
 
 const EXTENSION_ONLY_KEYS = {
   // InitializationOptions

--- a/src/common/settings.ts
+++ b/src/common/settings.ts
@@ -10,6 +10,7 @@ import { logger } from "./logger";
 
 export type Version = { major: number; minor: number; patch: number };
 type ImportStrategy = "fromEnvironment" | "useBundled";
+type UseUv = "off" | "scripts" | "on";
 
 type LogLevel = "error" | "warn" | "info" | "debug" | "trace";
 
@@ -17,6 +18,9 @@ export interface InitializationOptions {
   logLevel?: LogLevel;
   logFile?: string;
   untrustedWorkspace?: boolean;
+  experimental: {
+    useUv: UseUv;
+  };
 }
 
 export interface ExtensionSettings {
@@ -76,6 +80,12 @@ export function getInitializationOptions(
   const options: InitializationOptions = {
     logLevel: getOptionalGlobalValue<LogLevel>(config, "logLevel"),
     logFile: getOptionalGlobalValue<string>(config, "logFile"),
+    experimental: {
+      // uv can run code from the workspace, so do not use it in untrusted workspaces.
+      useUv: vscode.workspace.isTrusted
+        ? (config.get<UseUv>("experimental.useUv") ?? "off")
+        : "off",
+    },
   };
 
   // Unknown versions must still receive the trust restriction. Only omit it when

--- a/src/common/settings.ts
+++ b/src/common/settings.ts
@@ -81,10 +81,7 @@ export function getInitializationOptions(
     logLevel: getOptionalGlobalValue<LogLevel>(config, "logLevel"),
     logFile: getOptionalGlobalValue<string>(config, "logFile"),
     experimental: {
-      // uv can run code from the workspace, so do not use it in untrusted workspaces.
-      useUv: vscode.workspace.isTrusted
-        ? (config.get<UseUv>("experimental.useUv") ?? "off")
-        : "off",
+      useUv: config.get<UseUv>("experimental.useUv") ?? "off",
     },
   };
 

--- a/src/common/settings.ts
+++ b/src/common/settings.ts
@@ -18,7 +18,7 @@ export interface InitializationOptions {
   logLevel?: LogLevel;
   logFile?: string;
   untrustedWorkspace?: boolean;
-  experimental: {
+  experimental?: {
     useUv: UseUv;
   };
 }
@@ -80,10 +80,12 @@ export function getInitializationOptions(
   const options: InitializationOptions = {
     logLevel: getOptionalGlobalValue<LogLevel>(config, "logLevel"),
     logFile: getOptionalGlobalValue<string>(config, "logFile"),
-    experimental: {
-      useUv: config.get<UseUv>("experimental.useUv") ?? "off",
-    },
   };
+
+  const useUv = config.get<UseUv | null>("experimental.useUv");
+  if (useUv != null) {
+    options.experimental = { useUv };
+  }
 
   // Unknown versions must still receive the trust restriction. Only omit it when
   // we know the server is too old to support it.


### PR DESCRIPTION
## Summary
Similar to `TY_UV`, allow users to opt-in to the preview PEP 723 feature by setting `ty.experimental.useUv` to `on` or `scripts`. 

I expect this setting to change. E.g. I'm not sure if the options are `on`/`scripts` or `metadata`/`sync`, or if we have multiple settings etc. But that's why it's still in preview.

I also noticed that there are a few settings that are restricted in untrusted workspaces that we didn't correctly list. 

Needs https://github.com/astral-sh/ruff/pull/27619

## Test Plan


https://github.com/user-attachments/assets/ce970a67-5d29-4fa1-baf8-8fa895a75545

