### PR TITLE
Support ty.interpreter without a Python extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,8 +89,9 @@ recommend one of the following:
 - [Python](https://marketplace.visualstudio.com/items?itemName=ms-python.python)
 
 When either extension is available, ty can find an executable installed in the active Python
-environment. If that lookup fails, or neither extension is available, the extension checks `PATH`
-before using its bundled ty executable.
+environment. You can also set `ty.interpreter` to a Python executable without either extension.
+If no ty executable is found in a Python environment, the extension checks `PATH` before using its
+bundled ty executable.
 
 Reload VS Code after installing or enabling either extension.
 

--- a/README.md
+++ b/README.md
@@ -89,9 +89,9 @@ recommend one of the following:
 - [Python](https://marketplace.visualstudio.com/items?itemName=ms-python.python)
 
 When either extension is available, ty can find an executable installed in the active Python
-environment. You can also set `ty.interpreter` to a Python executable without either extension.
-If no ty executable is found in a Python environment, the extension checks `PATH` before using its
-bundled ty executable.
+environment. You can also set `ty.interpreter` to a Python executable or environment directory
+without either extension. If no ty executable is found in a Python environment, the extension
+checks `PATH` before using its bundled ty executable.
 
 Reload VS Code after installing or enabling either extension.
 

--- a/bundled/tool/find_ty_binary_path.py
+++ b/bundled/tool/find_ty_binary_path.py
@@ -30,6 +30,9 @@ def find_ty_binary_path() -> Optional[Path]:
 
 
 if __name__ == "__main__":
+    if sys.version_info.major != 3 or sys.version_info.minor < 8:
+        sys.exit("Finding ty requires Python 3.8 or later.")
+
     # Python defaults to the system's local encoding for stdout on Windows.
     # source: https://docs.python.org/3/library/sys.html#sys.stdout
     #

--- a/bundled/tool/find_ty_binary_path.py
+++ b/bundled/tool/find_ty_binary_path.py
@@ -30,9 +30,6 @@ def find_ty_binary_path() -> Optional[Path]:
 
 
 if __name__ == "__main__":
-    if sys.version_info.major != 3 or sys.version_info.minor < 8:
-        sys.exit("Finding ty requires Python 3.8 or later.")
-
     # Python defaults to the system's local encoding for stdout on Windows.
     # source: https://docs.python.org/3/library/sys.html#sys.stdout
     #

--- a/package.json
+++ b/package.json
@@ -152,7 +152,7 @@
         },
         "ty.interpreter": {
           "default": null,
-          "markdownDescription": "Path to a Python 3.8 or later executable used to find the ty executable. This setting works without the Python Environments or Python extension.",
+          "markdownDescription": "Path to a Python executable or environment directory used to find the ty executable. Python 3.8 or later is required. This setting works without the Python Environments or Python extension.",
           "scope": "window",
           "type": "string"
         },

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
             "useBundled"
           ],
           "enumDescriptions": [
-            "Use `ty` from the active Python environment if the Python Environments or Python extension is available, then from `PATH`, falling back to the bundled version.",
+            "Look for `ty` using the configured interpreter, or in the active Python environment when the Python Environments or Python extension is available. Fall back to `PATH`, then the bundled version.",
             "Always use the bundled version of `ty`."
           ],
           "scope": "window",
@@ -152,7 +152,7 @@
         },
         "ty.interpreter": {
           "default": null,
-          "markdownDescription": "Path to a Python interpreter used to find the ty executable. This setting requires the Python Environments or Python extension.",
+          "markdownDescription": "Path to a Python 3.8 or later executable used to find the ty executable. This setting works without the Python Environments or Python extension.",
           "scope": "window",
           "type": "string"
         },

--- a/src/common/server.ts
+++ b/src/common/server.ts
@@ -235,8 +235,11 @@ export async function findBinaryPath(
 
 async function resolvePythonExecutable(interpreterPath: string): Promise<string> {
   const stats = await fsapi.stat(interpreterPath).catch(() => undefined);
-  if (!stats?.isDirectory()) {
+  if (stats?.isFile()) {
     return interpreterPath;
+  }
+  if (!stats?.isDirectory()) {
+    throw new Error(`'${interpreterPath}' is not a file or directory.`);
   }
 
   // Match the Python extensions' native resolver, including MSYS2's bin layout on Windows.

--- a/src/common/server.ts
+++ b/src/common/server.ts
@@ -1,7 +1,7 @@
 import * as fsapi from "fs-extra";
 import { execFile } from "node:child_process";
 import { platform } from "node:os";
-import { resolve } from "node:path";
+import { join, resolve } from "node:path";
 import * as vscode from "vscode";
 import { type Disposable, l10n, LanguageStatusSeverity, type LogOutputChannel } from "vscode";
 import {
@@ -162,7 +162,9 @@ export async function findBinaryPath(
   } else if (userSpecifiedInterpreterPath != null) {
     logger.info(`Looking for ty using 'ty.interpreter': '${userSpecifiedInterpreterPath}'`);
     try {
-      const stdout = await executeFile(userSpecifiedInterpreterPath, [FIND_BINARY_SCRIPT_PATH]);
+      const executable = await resolvePythonExecutable(userSpecifiedInterpreterPath);
+      logger.info(`Resolved Python executable for ty lookup: '${executable}'`);
+      const stdout = await executeFile(executable, [FIND_BINARY_SCRIPT_PATH], cwd);
       tyBinaryPath = stdout.trim();
     } catch (err) {
       logger.warn(`Could not find ty using 'ty.interpreter': ${err}`);
@@ -229,6 +231,37 @@ export async function findBinaryPath(
     path: BUNDLED_EXECUTABLE,
     dependsOnActiveInterpreter,
   };
+}
+
+async function resolvePythonExecutable(interpreterPath: string): Promise<string> {
+  const stats = await fsapi.stat(interpreterPath).catch(() => undefined);
+  if (!stats?.isDirectory()) {
+    return interpreterPath;
+  }
+
+  // Match the Python extensions' native resolver, including MSYS2's bin layout on Windows.
+  // https://github.com/microsoft/python-environment-tools/blob/4b7a780391ec7d447689a740be5073fbd8968a3d/crates/pet-python-utils/src/executable.rs#L49-L75
+  const candidates =
+    platform() === "win32"
+      ? [
+          "Scripts/python.exe",
+          "Scripts/python3.exe",
+          "bin/python.exe",
+          "bin/python3.exe",
+          "python.exe",
+          "python3.exe",
+        ]
+      : ["bin/python", "bin/python3", "python", "python3"];
+
+  for (const candidate of candidates) {
+    const executable = join(interpreterPath, candidate);
+    const stats = await fsapi.stat(executable).catch(() => undefined);
+    if (stats?.isFile()) {
+      return executable;
+    }
+  }
+
+  throw new Error(`No Python executable found in '${interpreterPath}'.`);
 }
 
 async function createServer(

--- a/src/common/server.ts
+++ b/src/common/server.ts
@@ -159,6 +159,14 @@ export async function findBinaryPath(
         );
       }
     }
+  } else if (userSpecifiedInterpreterPath != null) {
+    logger.info(`Looking for ty using 'ty.interpreter': '${userSpecifiedInterpreterPath}'`);
+    try {
+      const stdout = await executeFile(userSpecifiedInterpreterPath, [FIND_BINARY_SCRIPT_PATH]);
+      tyBinaryPath = stdout.trim();
+    } catch (err) {
+      logger.warn(`Could not find ty using 'ty.interpreter': ${err}`);
+    }
   }
 
   if (interpreter != null) {


### PR DESCRIPTION
## Summary

Allow `ty.interpreter` to find a ty executable without either Python extension. 

Restricted mode always uses the bundled executable (unchanged). 



## Test Plan

https://github.com/user-attachments/assets/d509f72f-9603-4a0c-ac77-90188ceb0b59
