### PR TITLE
Automatically set `untrustedWorkspace` in `initializationOptions`

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -28,6 +28,7 @@ const EXTENSION_ONLY_KEYS = {
   // InitializationOptions
   logLevel: true,
   logFile: true,
+  untrustedWorkspace: true,
 
   // ExtensionSettings
   cwd: true,

--- a/src/common/server.ts
+++ b/src/common/server.ts
@@ -17,11 +17,7 @@ import {
   SERVER_SUBCOMMAND,
 } from "./constants";
 import { logger } from "./logger";
-import {
-  getInitializationOptions,
-  InitializationOptions,
-  type ExtensionSettings,
-} from "./settings";
+import { getInitializationOptions, type ExtensionSettings, type Version } from "./settings";
 import { updateStatus } from "./status";
 import { getDocumentSelector } from "./utilities";
 
@@ -228,7 +224,6 @@ async function createServer(
   serverName: string,
   outputChannel: LogOutputChannel,
   traceOutputChannel: LogOutputChannel,
-  initializationOptions: InitializationOptions,
   environmentProvider: EnvironmentProvider | null,
   middleware: TyMiddleware,
 ): Promise<ServerState> {
@@ -236,6 +231,9 @@ async function createServer(
     (await environmentProvider?.getActiveEnvironment(settings.cwd.uri)) ?? null;
   const binaryResolution = await findBinaryPath(settings, environmentProvider, activeEnvironment);
   const binaryPath = binaryResolution.path;
+  const version = await getTyVersion(binaryPath);
+  const initializationOptions = getInitializationOptions(serverId, version);
+  logger.info(`Initialization options: ${JSON.stringify(initializationOptions, null, 4)}`);
 
   const serverArgs: string[] = [SERVER_SUBCOMMAND];
   logger.info(`ty language server command: '${[binaryPath, ...serverArgs].join(" ")}'`);
@@ -267,6 +265,26 @@ async function createServer(
   };
 }
 
+/** Get the version before initialization, when startup-only options must be filtered. */
+async function getTyVersion(executable: string): Promise<Version | null> {
+  try {
+    const stdout = await executeFile(executable, ["--version"]);
+    // Development builds can report a Ruff tag, which is not a ty version.
+    const match = /^ty (\d+)\.(\d+)\.(\d+)(?:\+\d+)?(?: \([^()\r\n]*\))?$/.exec(stdout.trim());
+    if (match != null) {
+      return {
+        major: Number(match[1]),
+        minor: Number(match[2]),
+        patch: Number(match[3]),
+      };
+    }
+    logger.warn(`Could not parse ty version: ${stdout.trim()}`);
+  } catch (error) {
+    logger.warn(`Could not determine ty version: ${error}`);
+  }
+  return null;
+}
+
 export type ServerState = {
   client: LanguageClient;
   binaryResolution: BinaryResolution;
@@ -286,9 +304,6 @@ export async function startServer(
 ): Promise<ServerState | null> {
   updateStatus(undefined, LanguageStatusSeverity.Information, true);
 
-  const initializationOptions = getInitializationOptions(serverId);
-  logger.info(`Initialization options: ${JSON.stringify(initializationOptions, null, 4)}`);
-
   const middleware = createTyMiddleware(environmentProvider, fullDiagnosticProvider);
 
   const server = await createServer(
@@ -297,7 +312,6 @@ export async function startServer(
     serverName,
     outputChannel,
     traceOutputChannel,
-    initializationOptions,
     environmentProvider,
     middleware,
   );

--- a/src/common/server.ts
+++ b/src/common/server.ts
@@ -1,6 +1,7 @@
 import * as fsapi from "fs-extra";
 import { execFile } from "node:child_process";
 import { platform } from "node:os";
+import { resolve } from "node:path";
 import * as vscode from "vscode";
 import { type Disposable, l10n, LanguageStatusSeverity, type LogOutputChannel } from "vscode";
 import {
@@ -49,12 +50,13 @@ export function execFileShellModeRequired(file: string) {
 }
 
 /**
- * Function to execute a command and return the stdout.
+ * Run commands in the server's working directory so directory-sensitive shims
+ * select the same environment during discovery, version checks, and startup.
  */
-function executeFile(file: string, args: string[] = []): Promise<string> {
+function executeFile(file: string, args: string[], cwd: string): Promise<string> {
   const shell = execFileShellModeRequired(file);
   return new Promise((resolve, reject) => {
-    execFile(shell ? `"${file}"` : file, args, { shell }, (error, stdout, stderr) => {
+    execFile(shell ? `"${file}"` : file, args, { cwd, shell }, (error, stdout, stderr) => {
       if (error) {
         reject(new Error(stderr || error.message));
       } else {
@@ -98,9 +100,12 @@ export async function findBinaryPath(
     return { path: BUNDLED_EXECUTABLE, dependsOnActiveInterpreter: false };
   }
 
+  const cwd = settings.cwd.uri.fsPath;
+
   // 'path' setting takes priority over everything.
   if (settings.path.length > 0) {
-    for (const path of settings.path) {
+    for (const configuredPath of settings.path) {
+      const path = resolve(cwd, configuredPath);
       if (await fsapi.pathExists(path)) {
         logger.info(`Resolved ty executable from 'ty.path': '${path}'`);
         return { path, dependsOnActiveInterpreter: false };
@@ -168,7 +173,7 @@ export async function findBinaryPath(
 
       if (isSupportedPythonVersion) {
         try {
-          const stdout = await executeFile(interpreter.executable, [FIND_BINARY_SCRIPT_PATH]);
+          const stdout = await executeFile(interpreter.executable, [FIND_BINARY_SCRIPT_PATH], cwd);
           tyBinaryPath = stdout.trim();
         } catch (err) {
           vscode.window
@@ -227,11 +232,12 @@ async function createServer(
   environmentProvider: EnvironmentProvider | null,
   middleware: TyMiddleware,
 ): Promise<ServerState> {
+  const cwd = settings.cwd.uri.fsPath;
   const activeEnvironment =
     (await environmentProvider?.getActiveEnvironment(settings.cwd.uri)) ?? null;
   const binaryResolution = await findBinaryPath(settings, environmentProvider, activeEnvironment);
   const binaryPath = binaryResolution.path;
-  const version = await getTyVersion(binaryPath);
+  const version = await getTyVersion(binaryPath, cwd);
   const initializationOptions = getInitializationOptions(serverId, version);
   logger.info(`Initialization options: ${JSON.stringify(initializationOptions, null, 4)}`);
 
@@ -241,7 +247,7 @@ async function createServer(
   const serverOptions = {
     command: binaryPath,
     args: serverArgs,
-    options: { cwd: settings.cwd.uri.fsPath, env: process.env },
+    options: { cwd, env: process.env },
   };
 
   const clientOptions: LanguageClientOptions = {
@@ -266,9 +272,9 @@ async function createServer(
 }
 
 /** Get the version before initialization, when startup-only options must be filtered. */
-async function getTyVersion(executable: string): Promise<Version | null> {
+async function getTyVersion(executable: string, cwd: string): Promise<Version | null> {
   try {
-    const stdout = await executeFile(executable, ["--version"]);
+    const stdout = await executeFile(executable, ["--version"], cwd);
     const version = stdout.trim().split(" ")[1];
     // Development builds can report a Ruff tag, which is not a ty version.
     if (version != null && !version.startsWith("ruff/")) {

--- a/src/common/server.ts
+++ b/src/common/server.ts
@@ -269,14 +269,13 @@ async function createServer(
 async function getTyVersion(executable: string): Promise<Version | null> {
   try {
     const stdout = await executeFile(executable, ["--version"]);
+    const version = stdout.trim().split(" ")[1];
     // Development builds can report a Ruff tag, which is not a ty version.
-    const match = /^ty (\d+)\.(\d+)\.(\d+)(?:\+\d+)?(?: \([^()\r\n]*\))?$/.exec(stdout.trim());
-    if (match != null) {
-      return {
-        major: Number(match[1]),
-        minor: Number(match[2]),
-        patch: Number(match[3]),
-      };
+    if (version != null && !version.startsWith("ruff/")) {
+      const [major, minor, patch] = version.split(".").map((part) => parseInt(part, 10));
+      if (!isNaN(major) && !isNaN(minor) && !isNaN(patch)) {
+        return { major, minor, patch };
+      }
     }
     logger.warn(`Could not parse ty version: ${stdout.trim()}`);
   } catch (error) {

--- a/src/common/settings.ts
+++ b/src/common/settings.ts
@@ -8,7 +8,7 @@ import * as vscode from "vscode";
 import { getConfiguration, getWorkspaceFolders } from "./vscodeapi";
 import { logger } from "./logger";
 
-type Version = { major: number; minor: number; patch: number };
+export type Version = { major: number; minor: number; patch: number };
 type ImportStrategy = "fromEnvironment" | "useBundled";
 
 type LogLevel = "error" | "warn" | "info" | "debug" | "trace";
@@ -16,6 +16,7 @@ type LogLevel = "error" | "warn" | "info" | "debug" | "trace";
 export interface InitializationOptions {
   logLevel?: LogLevel;
   logFile?: string;
+  untrustedWorkspace?: boolean;
 }
 
 export interface ExtensionSettings {
@@ -65,12 +66,26 @@ export function resolveVariables(
   }
 }
 
-export function getInitializationOptions(namespace: string): InitializationOptions {
+// TODO: Verify the first release containing https://github.com/astral-sh/ruff/pull/27828.
+const UNTRUSTED_WORKSPACE_SUPPORTED_SINCE: Version = { major: 0, minor: 0, patch: 73 };
+
+export function getInitializationOptions(
+  namespace: string,
+  serverVersion: Version | null,
+): InitializationOptions {
   const config = getConfiguration(namespace);
-  return {
+  const options: InitializationOptions = {
     logLevel: getOptionalGlobalValue<LogLevel>(config, "logLevel"),
     logFile: getOptionalGlobalValue<string>(config, "logFile"),
   };
+
+  // Unknown versions must still receive the trust restriction. Only omit it when
+  // we know the server is too old to support it.
+  if (serverVersion == null || isNewerThan(serverVersion, UNTRUSTED_WORKSPACE_SUPPORTED_SINCE)) {
+    options.untrustedWorkspace = !vscode.workspace.isTrusted;
+  }
+
+  return options;
 }
 
 function getInterpreterFromSetting(namespace: string, scope?: ConfigurationScope): string | null {

--- a/src/common/settings.ts
+++ b/src/common/settings.ts
@@ -66,8 +66,7 @@ export function resolveVariables(
   }
 }
 
-// TODO: Verify the first release containing https://github.com/astral-sh/ruff/pull/27828.
-const UNTRUSTED_WORKSPACE_SUPPORTED_SINCE: Version = { major: 0, minor: 0, patch: 73 };
+const UNTRUSTED_WORKSPACE_SUPPORTED_SINCE: Version = { major: 0, minor: 0, patch: 74 };
 
 export function getInitializationOptions(
   namespace: string,


### PR DESCRIPTION
## Summary

Pass VS Code workspace trust to ty using the initialization option added in https://github.com/astral-sh/ruff/pull/27828.


We only set the option for servers that support the options, because `initializationOptions` otherwise fail to deserialize.

## Test Plan

https://github.com/user-attachments/assets/e779d7b0-ec41-44d9-8a2c-63723986656c


