### PR TITLE
Refactor release to use our release-gate pattern

### DIFF
--- a/.github/workflows/release-prepare.yaml
+++ b/.github/workflows/release-prepare.yaml
@@ -1,0 +1,100 @@
+# Bump the extension and bundled ty versions and create a pull request.
+name: Prepare release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Exact extension version to release, without a leading v
+        required: true
+        type: string
+      ty-version:
+        description: Bundled ty version (defaults to the latest version on PyPI)
+        required: false
+        type: string
+
+permissions: {}
+
+jobs:
+  prepare:
+    name: Prepare release
+    if: github.repository == 'astral-sh/ty-vscode' && github.ref_name == github.event.repository.default_branch
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          python-version: "3.13"
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "24.19.0"
+          package-manager-cache: false
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Bump version
+        shell: bash
+        run: |
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Invalid extension version: ${VERSION}"
+            exit 1
+          fi
+          if git rev-parse --verify --quiet "refs/tags/${VERSION}" >/dev/null; then
+            echo "::error::Tag ${VERSION} already exists"
+            exit 1
+          fi
+
+          args=(--new-version "$VERSION")
+          if [[ -n "$TY_VERSION" ]]; then
+            args+=(--new-ty "$TY_VERSION")
+          fi
+          uv run --locked scripts/release.py "${args[@]}"
+
+          package_version="$(node -p 'require("./package.json").version')"
+          if [[ "$package_version" != "$VERSION" ]]; then
+            echo "::error::Requested version ${VERSION} was normalized to ${package_version}"
+            exit 1
+          fi
+        env:
+          VERSION: ${{ inputs.version }}
+          TY_VERSION: ${{ inputs.ty-version }}
+
+      - name: Create or update pull request
+        run: |
+          branch="release/${VERSION}"
+          git switch -c "$branch"
+          git add package.json package-lock.json pyproject.toml uv.lock requirements.txt README.md
+          git commit -m "Release ${VERSION}"
+          git push --force "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "HEAD:refs/heads/${branch}"
+
+          pull_request="$(
+            gh pr list \
+              --base "$DEFAULT_BRANCH" \
+              --head "$branch" \
+              --state open \
+              --json url \
+              --jq '.[0].url'
+          )"
+          if [ -n "$pull_request" ]; then
+            printf '%s\n' "$pull_request"
+          else
+            gh pr create \
+              --base "$DEFAULT_BRANCH" \
+              --head "$branch" \
+              --fill-first
+          fi
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ inputs.version }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -40,35 +40,12 @@ jobs:
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.x"
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
       - name: Validate release metadata
         id: metadata
         shell: bash
         run: |
-          python - <<'PY'
-          import json
-          import os
-          import re
-          import tomllib
-          from pathlib import Path
-
-          version = os.environ["VERSION"]
-          if not re.fullmatch(r"(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)", version):
-              raise SystemExit(f"Invalid extension version: {version!r}")
-          package = json.loads(Path("package.json").read_text())
-          project = tomllib.loads(Path("pyproject.toml").read_text())["project"]
-          for name, metadata in [("package.json", package), ("pyproject.toml", project)]:
-              if metadata["version"] != version:
-                  raise SystemExit(f"Requested version {version} does not match {name} version {metadata['version']}")
-          prerelease = int(version.split(".")[1]) % 2 != 0
-          with open(os.environ["GITHUB_OUTPUT"], "a") as output:
-              print(f"prerelease={str(prerelease).lower()}", file=output)
-          PY
-
-          if git rev-parse --verify --quiet "refs/tags/${VERSION}" >/dev/null; then
-            echo "::error::Tag ${VERSION} already exists"
-            exit 1
-          fi
-
+          uv run --locked scripts/release.py --validate "$VERSION" >> "$GITHUB_OUTPUT"
           echo "Preparing ${VERSION} from ${GITHUB_SHA}" >> "$GITHUB_STEP_SUMMARY"
         env:
           VERSION: ${{ inputs.version }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,13 +1,16 @@
+# Validate and publish a release, then create its tag and GitHub release.
 name: Release
 on:
   workflow_dispatch:
     inputs:
-      prerelease:
-        description: "Build as prerelease/nightly"
-        type: boolean
-        default: false
-  release:
-    types: [published]
+      version:
+        description: Exact extension version to release, without a leading v
+        required: true
+        type: string
+
+concurrency:
+  group: release
+  cancel-in-progress: false
 
 env:
   FETCH_DEPTH: 0
@@ -15,13 +18,17 @@ env:
 permissions: {}
 
 jobs:
-  # Phase 1: Generate the Build ID.
+  # Phase 1: Validate the release and generate the Build ID.
   # We have to do this ahead-of-time, and store it as a job output,
   # to ensure that we use the same Build ID across all build jobs.
-  build-id:
-    name: "Build ID"
+  validate-release:
+    name: Validate release
+    if: github.repository == 'astral-sh/ty-vscode' && github.ref_name == github.event.repository.default_branch
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
+      prerelease: ${{ steps.metadata.outputs.prerelease }}
       release-build-id: ${{ steps.release-build-id-generator.outputs.release-build-id }}
       nightly-build-id: ${{ steps.nightly-build-id-generator.outputs.nightly-build-id }}
     steps:
@@ -33,15 +40,47 @@ jobs:
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.x"
+      - name: Validate release metadata
+        id: metadata
+        shell: bash
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          import re
+          import tomllib
+          from pathlib import Path
+
+          version = os.environ["VERSION"]
+          if not re.fullmatch(r"(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)", version):
+              raise SystemExit(f"Invalid extension version: {version!r}")
+          package = json.loads(Path("package.json").read_text())
+          project = tomllib.loads(Path("pyproject.toml").read_text())["project"]
+          for name, metadata in [("package.json", package), ("pyproject.toml", project)]:
+              if metadata["version"] != version:
+                  raise SystemExit(f"Requested version {version} does not match {name} version {metadata['version']}")
+          prerelease = int(version.split(".")[1]) % 2 != 0
+          with open(os.environ["GITHUB_OUTPUT"], "a") as output:
+              print(f"prerelease={str(prerelease).lower()}", file=output)
+          PY
+
+          if git rev-parse --verify --quiet "refs/tags/${VERSION}" >/dev/null; then
+            echo "::error::Tag ${VERSION} already exists"
+            exit 1
+          fi
+
+          echo "Preparing ${VERSION} from ${GITHUB_SHA}" >> "$GITHUB_STEP_SUMMARY"
+        env:
+          VERSION: ${{ inputs.version }}
       - name: Generate Build ID (release)
-        if: ${{ (github.event_name == 'workflow_dispatch' && !inputs.prerelease) || (github.event_name == 'release' && !github.event.release.prerelease) }}
+        if: steps.metadata.outputs.prerelease == 'false'
         id: release-build-id-generator
         run: |
           release_build_id="$(python -m build.generate_build_id)"
           echo "release-build-id: ${release_build_id}"
           echo "release-build-id=${release_build_id}" >> "$GITHUB_OUTPUT"
       - name: Generate Build ID (nightly)
-        if: ${{ (github.event_name == 'workflow_dispatch' && inputs.prerelease) || (github.event_name == 'release' && github.event.release.prerelease) }}
+        if: steps.metadata.outputs.prerelease == 'true'
         id: nightly-build-id-generator
         run: |
           nightly_build_id="$(python -m build.generate_build_id --pre-release)"
@@ -86,9 +125,10 @@ jobs:
             arch: aarch64
 
     name: Build (${{ matrix.target }})
-    needs: ["build-id"]
+    needs: ["validate-release"]
     runs-on: ${{ matrix.os }}
-    container: ${{ matrix.container }}
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout repository
@@ -152,27 +192,27 @@ jobs:
 
       # Set the Build ID.
       - name: Set Build ID (release)
-        if: ${{ (github.event_name == 'workflow_dispatch' && !inputs.prerelease) || (github.event_name == 'release' && !github.event.release.prerelease) }}
+        if: needs.validate-release.outputs.prerelease == 'false'
         shell: bash
         run: |
           python -m build.update_ext_version --build-id "${BUILD_ID}" --for-publishing
         env:
-          BUILD_ID: ${{ needs.build-id.outputs.release-build-id }}
+          BUILD_ID: ${{ needs.validate-release.outputs.release-build-id }}
       - name: Set Build ID (nightly)
-        if: ${{ (github.event_name == 'workflow_dispatch' && inputs.prerelease) || (github.event_name == 'release' && github.event.release.prerelease) }}
+        if: needs.validate-release.outputs.prerelease == 'true'
         shell: bash
         run: |
           python -m build.update_ext_version --build-id "${BUILD_ID}" --for-publishing --pre-release
         env:
-          BUILD_ID: ${{ needs.build-id.outputs.nightly-build-id }}
+          BUILD_ID: ${{ needs.validate-release.outputs.nightly-build-id }}
 
       # Build the extension.
       - name: Package Extension (release)
-        if: ${{ (github.event_name == 'workflow_dispatch' && !inputs.prerelease) || (github.event_name == 'release' && !github.event.release.prerelease) }}
+        if: needs.validate-release.outputs.prerelease == 'false'
         shell: bash
         run: npx vsce package -o "./dist/ty-${{ matrix.code-target }}.vsix" --target ${{ matrix.code-target }}
       - name: Package Extension (nightly)
-        if: ${{ (github.event_name == 'workflow_dispatch' && inputs.prerelease) || (github.event_name == 'release' && github.event.release.prerelease) }}
+        if: needs.validate-release.outputs.prerelease == 'true'
         shell: bash
         run: npx vsce package -o "./dist/ty-${{ matrix.code-target }}.vsix" --target ${{ matrix.code-target }} --pre-release
 
@@ -183,11 +223,27 @@ jobs:
           name: dist-${{ matrix.target }}
           path: ./dist
 
-  # Phase 3: Publish the built extension to the Marketplace.
+  # Phase 3: Approve the release after all platform builds succeed.
+  release-gate:
+    # N.B. This name should not change; the release environment gate relies on it.
+    name: release-gate
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: release-gate
+    permissions: {}
+    steps:
+      - run: echo "Release approved"
+
+  # Phase 4: Publish the built extension to both marketplaces.
   publish-code-marketplace:
     name: "Publish (Code Marketplace)"
-    needs: ["build"]
+    needs: ["validate-release", "release-gate"]
     runs-on: ubuntu-latest
+    environment:
+      name: release
+    permissions:
+      contents: read
     steps:
       - name: Install Nodejs
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -245,16 +301,24 @@ jobs:
 
       # Publish to the Code Marketplace.
       - name: Publish Extension (Code Marketplace, release)
-        if: ${{ (github.event_name == 'workflow_dispatch' && !inputs.prerelease) || (github.event_name == 'release' && !github.event.release.prerelease) }}
-        run: npx vsce publish --pat ${{ secrets.MARKETPLACE_TOKEN }} --packagePath ./dist/ty-*.vsix --skip-duplicate
+        if: needs.validate-release.outputs.prerelease == 'false'
+        run: npx vsce publish --packagePath ./dist/ty-*.vsix --skip-duplicate
+        env:
+          VSCE_PAT: ${{ secrets.MARKETPLACE_TOKEN }}
       - name: Publish Extension (Code Marketplace, nightly)
-        if: ${{ (github.event_name == 'workflow_dispatch' && inputs.prerelease) || (github.event_name == 'release' && github.event.release.prerelease) }}
-        run: npx vsce publish --pat ${{ secrets.MARKETPLACE_TOKEN }} --packagePath ./dist/ty-*.vsix --pre-release --skip-duplicate
+        if: needs.validate-release.outputs.prerelease == 'true'
+        run: npx vsce publish --packagePath ./dist/ty-*.vsix --pre-release --skip-duplicate
+        env:
+          VSCE_PAT: ${{ secrets.MARKETPLACE_TOKEN }}
 
   publish-openvsx:
     name: "Publish (OpenVSX)"
-    needs: ["build"]
+    needs: ["validate-release", "release-gate"]
     runs-on: ubuntu-latest
+    environment:
+      name: release
+    permissions:
+      contents: read
     steps:
       - name: Install Nodejs
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -312,10 +376,41 @@ jobs:
 
       # Publish to OpenVSX.
       - name: Publish Extension (OpenVSX, release)
-        if: ${{ (github.event_name == 'workflow_dispatch' && !inputs.prerelease) || (github.event_name == 'release' && !github.event.release.prerelease) }}
-        run: npx ovsx publish --pat ${{ secrets.OPENVSX_TOKEN }} --packagePath ./dist/ty-*.vsix --skip-duplicate
+        if: needs.validate-release.outputs.prerelease == 'false'
+        run: npx ovsx publish --packagePath ./dist/ty-*.vsix --skip-duplicate
+        env:
+          OVSX_PAT: ${{ secrets.OPENVSX_TOKEN }}
         timeout-minutes: 2
       - name: Publish Extension (OpenVSX, nightly)
-        if: ${{ (github.event_name == 'workflow_dispatch' && inputs.prerelease) || (github.event_name == 'release' && github.event.release.prerelease) }}
-        run: npx ovsx publish --pat ${{ secrets.OPENVSX_TOKEN }} --packagePath ./dist/ty-*.vsix --pre-release --skip-duplicate
+        if: needs.validate-release.outputs.prerelease == 'true'
+        run: npx ovsx publish --packagePath ./dist/ty-*.vsix --pre-release --skip-duplicate
+        env:
+          OVSX_PAT: ${{ secrets.OPENVSX_TOKEN }}
         timeout-minutes: 2
+
+  # Phase 5: Create the tag and GitHub release after both publications succeed.
+  publish-github:
+    name: Create GitHub release
+    needs: ["validate-release", "publish-code-marketplace", "publish-openvsx"]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Create GitHub release and tag
+        shell: bash
+        run: |
+          prerelease=()
+          if [[ "$PRERELEASE" == "true" ]]; then
+            prerelease+=(--prerelease)
+          fi
+          gh release create "$VERSION" \
+            --repo "$GITHUB_REPOSITORY" \
+            --target "$RELEASE_COMMIT" \
+            --title "$VERSION" \
+            --generate-notes \
+            "${prerelease[@]}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PRERELEASE: ${{ needs.validate-release.outputs.prerelease }}
+          RELEASE_COMMIT: ${{ github.sha }}
+          VERSION: ${{ inputs.version }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,19 +40,20 @@ The ty server's experimental Language Server Protocol extensions are documented 
 
 ## Release
 
-- Run `uv run scripts/release.py`.
-  (Run `uv run scripts/release.py --help` for information on what this script does,
-  and its various options.)
-- Check the changes the script made, and commit the changes. Note that the version number
-  increases in steps of two by default (e.g. `2025.5.0 -> 2025.7.0`). Odd-numbered versions
-  are pre-releases, even-numbered versions are stable releases.
-- Create a new PR and merge it.
-- [Create a new Release](https://github.com/astral-sh/ty-vscode/releases/new):
-  - Enter `x.x.x` (where `x.x.x` is the new version) into the _Choose a tag_ selector.
-  - Click "Create new tag: ... on publish".
-  - Click _Generate release notes_, curate the release notes and publish the release.
-  - Be sure to select _Set as a pre-release_ if this is a pre-release (odd minor version).
-  - Click _Publish release_.
-- The [Release workflow](https://github.com/astral-sh/ty-vscode/actions/workflows/release.yaml)
-  should automatically pick up the new release and publish the extension to the VS Code marketplace.
-  Note that it may take a few minutes after the workflow completes for the extension to be available.
+1. Run the [Prepare release workflow](https://github.com/astral-sh/ty-vscode/actions/workflows/release-prepare.yaml)
+   from `main` with the exact extension version, without a leading `v`.
+   Optionally specify the bundled ty version; it defaults to the latest version on PyPI.
+2. Review and merge the generated release PR. The workflow runs `scripts/release.py` to update
+   the extension version, bundled ty version, README, and lockfiles.
+3. Run the [Release workflow](https://github.com/astral-sh/ty-vscode/actions/workflows/release.yaml)
+   from `main` with the same extension version.
+4. Approve the protected `release-gate` deployment after all platform builds succeed.
+
+The release workflow checks that the requested version matches `package.json` and `pyproject.toml`
+and that its tag does not already exist. Odd minor versions are pre-releases and retain timestamped
+nightly build IDs; even minor versions are stable releases. Publication to the VS Code Marketplace
+and OpenVSX uses the `release` environment. After both publications succeed, the workflow creates
+the `<version>` tag and GitHub release, automatically marking odd minor versions as pre-releases.
+Review and curate the generated GitHub release notes as needed.
+
+It may take a few minutes after the workflow completes for the extension to be available.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,11 +49,9 @@ The ty server's experimental Language Server Protocol extensions are documented 
    from `main` with the same extension version.
 4. Approve the protected `release-gate` deployment after all platform builds succeed.
 
-The release workflow checks that the requested version matches `package.json` and `pyproject.toml`
-and that its tag does not already exist. Odd minor versions are pre-releases and retain timestamped
-nightly build IDs; even minor versions are stable releases. Publication to the VS Code Marketplace
-and OpenVSX uses the `release` environment. After both publications succeed, the workflow creates
-the `<version>` tag and GitHub release, automatically marking odd minor versions as pre-releases.
-Review and curate the generated GitHub release notes as needed.
+Odd minor versions are pre-releases and retain timestamped nightly build IDs; even minor versions are stable releases.
+
+After both publications succeed, the workflow creates the `<version>` tag and GitHub release, automatically marking odd
+minor versions as pre-releases. Review and curate the generated GitHub release notes as needed.
 
 It may take a few minutes after the workflow completes for the extension to be available.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,10 +41,10 @@ The ty server's experimental Language Server Protocol extensions are documented 
 ## Release
 
 1. Run the [Prepare release workflow](https://github.com/astral-sh/ty-vscode/actions/workflows/release-prepare.yaml)
-   from `main` with the exact extension version, without a leading `v`.
-   Optionally specify the bundled ty version; it defaults to the latest version on PyPI.
-2. Review and merge the generated release PR. The workflow runs `scripts/release.py` to update
+   from `main` with the exact extension version, without a leading `v`. The workflow runs `scripts/release.py` to update
    the extension version, bundled ty version, README, and lockfiles.
+   Optionally specify the bundled ty version; it defaults to the latest version on PyPI.
+2. Review and merge the generated release PR.
 3. Run the [Release workflow](https://github.com/astral-sh/ty-vscode/actions/workflows/release.yaml)
    from `main` with the same extension version.
 4. Approve the protected `release-gate` deployment after all platform builds succeed.

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -231,8 +231,14 @@ def prepare_release(versions: Versions, *, prepare_pr: bool) -> None:
 
 def validate_release(version: str) -> bool:
     """Validate release metadata and return whether this is a pre-release."""
-    if not re.fullmatch(r"(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)", version):
+    if not re.fullmatch(r"[0-9]+\.[0-9]+\.[0-9]+", version):
         raise SystemExit(f"Invalid extension version: {version!r}")
+
+    parsed_version = Version(version)
+    if str(parsed_version) != version:
+        raise SystemExit(
+            f"Requested version {version} was normalized to {parsed_version}"
+        )
 
     with PACKAGE_JSON_PATH.open("rb") as package_file:
         package = json.load(package_file)
@@ -257,7 +263,7 @@ def validate_release(version: str) -> bool:
     if tag:
         raise SystemExit(f"Tag {version} already exists")
 
-    return Version(version).minor % 2 != 0
+    return parsed_version.minor % 2 != 0
 
 
 def main() -> None:

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -6,6 +6,8 @@ This script does the following things:
 - Bumps the `ty` dependency pin in `pyproject.toml`
 - Updates the changelog and README
 - Updates the package's lockfiles
+
+Use --validate VERSION to check an existing release without modifying files.
 """
 
 # /// script
@@ -227,9 +229,48 @@ def prepare_release(versions: Versions, *, prepare_pr: bool) -> None:
         commit_changes(versions)
 
 
+def validate_release(version: str) -> bool:
+    """Validate release metadata and return whether this is a pre-release."""
+    if not re.fullmatch(r"(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)", version):
+        raise SystemExit(f"Invalid extension version: {version!r}")
+
+    with PACKAGE_JSON_PATH.open("rb") as package_file:
+        package = json.load(package_file)
+    with PYPROJECT_TOML_PATH.open("rb") as project_file:
+        project = tomli.load(project_file)["project"]
+    for path, metadata in [
+        (PACKAGE_JSON_PATH, package),
+        (PYPROJECT_TOML_PATH, project),
+    ]:
+        if metadata["version"] != version:
+            raise SystemExit(
+                f"Requested version {version} does not match "
+                f"{path} version {metadata['version']}"
+            )
+
+    tag = subprocess.run(
+        ["git", "tag", "--list", version],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    if tag:
+        raise SystemExit(f"Tag {version} already exists")
+
+    return Version(version).minor % 2 != 0
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(
         description=__doc__, formatter_class=RawDescriptionRichHelpFormatter
+    )
+    parser.add_argument(
+        "--validate",
+        metavar="VERSION",
+        help=(
+            "Validate an existing release without modifying files; "
+            "prints prerelease=true or prerelease=false"
+        ),
     )
     parser.add_argument(
         "--prepare-pr",
@@ -253,6 +294,15 @@ def main() -> None:
         ),
     )
     args = parser.parse_args()
+    if args.validate is not None:
+        if args.prepare_pr or args.new_version is not None or args.new_ty is not None:
+            parser.error(
+                "--validate cannot be combined with release preparation options"
+            )
+        prerelease = validate_release(args.validate)
+        print(f"prerelease={str(prerelease).lower()}")
+        return
+
     versions = get_ty_versions(
         new_ty_vscode_version=args.new_version,
         new_ty_version=args.new_ty,


### PR DESCRIPTION
## Summary

This switches `ty-vscode` to the same release-gate pattern as our other repos.

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

NFC, CI only. We should probably smoke-test this with a prerelease.

<!-- How was it tested? -->
